### PR TITLE
[#16] 로그인API연동 및 JWT토큰 localstorage 저장 구현

### DIFF
--- a/src/app/(pages)/auth/layouts/Header.tsx
+++ b/src/app/(pages)/auth/layouts/Header.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react"
 import { usePathname, useSearchParams } from "next/navigation"
 import Logo from "../../main/assets/Logo.png"
 import { Button } from "../components/ui/button"
+import { ACCESS_TOKEN_KEY } from "@/lib/auth"
 
 export function Header() {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
@@ -20,15 +21,14 @@ export function Header() {
     "text-sm font-semibold cursor-pointer relative after:content-[''] after:absolute after:left-0 after:-bottom-1.5 after:h-[2px] after:bg-current after:transition-all after:duration-200"
 
   useEffect(() => {
-    if (typeof document === 'undefined') return
-    const match = document.cookie
-      .split(';')
-      .map((c) => c.trim())
-      .find((c) => c.startsWith('logged_in='))
-    if (match) {
-      const value = decodeURIComponent(match.split('=')[1] || '')
-      setIsLoggedIn(value === 'true')
+    if (typeof window === "undefined") return
+    const hasAccessToken = !!localStorage.getItem(ACCESS_TOKEN_KEY)
+    if (hasAccessToken) {
+      setIsLoggedIn(true)
+      return
     }
+    const loggedFlag = localStorage.getItem("logged_in")
+    setIsLoggedIn(loggedFlag === "true")
   }, [])
 
   return (
@@ -43,13 +43,13 @@ export function Header() {
               href="/main?tab=offering"
               className={`${navBase} ${isOfferingActive ? 'after:w-full' : 'after:w-0 hover:after:w-full'}`}
             >
-              {'\uACF5\uBAA8'}
+              {'공모'}
             </Link>
             <Link
               href="/main?tab=trading"
               className={`${navBase} ${isTradingActive ? 'after:w-full' : 'after:w-0 hover:after:w-full'}`}
             >
-              {'\uC99D\uAD8C \uAC70\uB798'}
+              {'증권 거래'}
             </Link>
           </nav>
         </div>
@@ -62,10 +62,10 @@ export function Header() {
           ) : (
             <>
               <Button asChild size="sm" className="bg-[#3386E5] text-white hover:bg-[#2a6bc4] cursor-pointer">
-                <Link href="/auth/login">{'\uB85C\uADF8\uC778'}</Link>
+                <Link href="/auth/login">{'로그인'}</Link>
               </Button>
               <Button asChild size="sm" className="bg-[#F2F2F7] text-[#303030] hover:bg-[#e5e5ea] cursor-pointer">
-                <Link href="/auth/verification">{'\uD68C\uC6D0\uAC00\uC785'}</Link>
+                <Link href="/auth/verification">{'회원가입'}</Link>
               </Button>
             </>
           )}

--- a/src/app/(pages)/auth/layouts/Header.tsx
+++ b/src/app/(pages)/auth/layouts/Header.tsx
@@ -23,12 +23,7 @@ export function Header() {
   useEffect(() => {
     if (typeof window === "undefined") return
     const hasAccessToken = !!localStorage.getItem(ACCESS_TOKEN_KEY)
-    if (hasAccessToken) {
-      setIsLoggedIn(true)
-      return
-    }
-    const loggedFlag = localStorage.getItem("logged_in")
-    setIsLoggedIn(loggedFlag === "true")
+    setIsLoggedIn(hasAccessToken)
   }, [])
 
   return (

--- a/src/app/(pages)/auth/login/page.tsx
+++ b/src/app/(pages)/auth/login/page.tsx
@@ -59,11 +59,6 @@ export default function LoginPage() {
       if (data.accessToken) localStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken)
       if (data.refreshToken) localStorage.setItem(REFRESH_TOKEN_KEY, data.refreshToken)
 
-      if (typeof window !== "undefined") {
-        // lightweight logged-in flag for UI; token validation should be done server-side where needed
-        localStorage.setItem("logged_in", "true")
-      }
-
       router.push("/main")
     } catch (err) {
       console.error("Login failed", err)

--- a/src/app/(pages)/auth/login/page.tsx
+++ b/src/app/(pages)/auth/login/page.tsx
@@ -1,7 +1,6 @@
-﻿"use client"
+"use client"
 
 import type React from "react"
-
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import Image from "next/image"
@@ -9,18 +8,75 @@ import Link from "next/link"
 import { Input } from "../components/ui/input"
 import { Button } from "../components/ui/button"
 import Logo from "../../main/assets/Logo.png"
+import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "@/lib/auth"
+import { apiFetch } from "@/lib/api-client"
 
 export default function LoginPage() {
   const router = useRouter()
   const [formData, setFormData] = useState({ username: "", password: "" })
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    const oneWeek = 60 * 60 * 24 * 7
-    const username = formData.username || 'guest'
-    document.cookie = `logged_in=true; Max-Age=${oneWeek}; Path=/`
-    document.cookie = `user_name=${encodeURIComponent(username)}; Max-Age=${oneWeek}; Path=/`
-    router.push('/main')
+    setError(null)
+
+    if (!formData.username.trim() || !formData.password) {
+      setError("아이디와 비밀번호를 입력해주세요.")
+      return
+    }
+
+    setIsLoading(true)
+
+    try {
+      const res = await apiFetch(`/v1/auth/token/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: formData.username.trim(),
+          password: formData.password,
+        }),
+      })
+
+      if (!res.ok) {
+        let detailMessage: string | undefined
+        try {
+          const errBody = (await res.json()) as { detail?: string }
+          detailMessage = errBody?.detail
+        } catch (parseErr) {
+          console.error("Failed to parse error response", parseErr)
+        }
+        setError(detailMessage || `로그인에 실패했습니다. (코드 ${res.status})`)
+        return
+      }
+
+      const data = (await res.json()) as {
+        accessToken?: string
+        refreshToken?: string
+        message?: string
+      }
+
+      if (data.accessToken) localStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken)
+      if (data.refreshToken) localStorage.setItem(REFRESH_TOKEN_KEY, data.refreshToken)
+
+      if (typeof window !== "undefined") {
+        // lightweight logged-in flag for UI; token validation should be done server-side where needed
+        localStorage.setItem("logged_in", "true")
+      }
+
+      router.push("/main")
+    } catch (err) {
+      console.error("Login failed", err)
+      const message =
+        err instanceof TypeError
+          ? "서버에 연결할 수 없습니다. 네트워크를 확인하거나 잠시 후 다시 시도해주세요."
+          : err instanceof Error && err.message
+            ? err.message
+            : "아이디/비밀번호를 확인하거나 잠시 후 다시 시도해주세요."
+      setError(message)
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   return (
@@ -35,14 +91,14 @@ export default function LoginPage() {
       {/* Card */}
       <div className="bg-[#FAFAFA] rounded-[10px] p-10 w-full max-w-[470px] border border-gray-200">
         <div className="mx-auto w-[86%]">
-          <h1 className="text-[20px] font-bold text-left mb-5">{"\uB85C\uADF8\uC778"}</h1>
+          <h1 className="text-[20px] font-bold text-left mb-5">{"로그인"}</h1>
 
           <form onSubmit={handleSubmit} className="space-y-5">
             <div>
-              <label className="block text-[12px] font-semibold mb-1">{"\uC544\uC774\uB514"}</label>
+              <label className="block text-[12px] font-semibold mb-1">{"아이디"}</label>
               <Input
                 type="text"
-                placeholder={"\uC544\uC774\uB514\uB97C \uC785\uB825\uD574\uC8FC\uC138\uC694."}
+                placeholder={"아이디를 입력해주세요."}
                 value={formData.username}
                 onChange={(e) => setFormData({ ...formData, username: e.target.value })}
                 className="w-full h-[48px] text-[14px] text-[#1F2229] rounded-[8px] border border-[#E0E4EC] bg-white placeholder:text-[12px] placeholder:text-[#6C7384] focus-visible:ring-0 focus-visible:border-[#3386E5]"
@@ -50,10 +106,10 @@ export default function LoginPage() {
             </div>
 
             <div>
-              <label className="block text-[12px] font-semibold mb-1">{"\uBE44\uBC00\uBC88\uD638"}</label>
+              <label className="block text-[12px] font-semibold mb-1">{"비밀번호"}</label>
               <Input
                 type="password"
-                placeholder={"\uBE44\uBC00\uBC88\uD638\uB97C \uC785\uB825\uD574\uC8FC\uC138\uC694."}
+                placeholder={"비밀번호를 입력해주세요."}
                 value={formData.password}
                 onChange={(e) => setFormData({ ...formData, password: e.target.value })}
                 className="w-full h-[48px] text-[14px] text-[#1F2229] rounded-[8px] border border-[#E0E4EC] bg-white placeholder:text-[12px] placeholder:text-[#6C7384] focus-visible:ring-0 focus-visible:border-[#3386E5]"
@@ -63,17 +119,19 @@ export default function LoginPage() {
             <Button
               type="submit"
               className="w-full bg-[#3386E5] text-white py-6 rounded-[8px] text-[13px] font-semibold hover:bg-[#2970cc] transition mt-8 flex items-center justify-center cursor-pointer disabled:cursor-not-allowed"
+              disabled={isLoading}
             >
-              {"\uB2E4\uC74C"}
+              {isLoading ? "로그인 중..." : "다음"}
             </Button>
+            {error ? <p className="text-xs text-red-500 text-center">{error}</p> : null}
           </form>
           <div className="text-center mt-6 text-[11px]">
-            <span className="text-[#A2A2A2] text-[11px]">{"IPiece\uAC00 \uCC98\uC74C\uC774\uC2E0\uAC00\uC694?"}</span>
+            <span className="text-[#A2A2A2] text-[11px]">{"IPiece가 처음이신가요?"}</span>
             <button
               onClick={() => router.push("/auth/verification")}
               className="ml-3 text-[#3386E5] font-semibold text-[12px] cursor-pointer no-underline"
             >
-              {"\uD68C\uC6D0\uAC00\uC785"}
+              {"회원가입"}
             </button>
           </div>
         </div>

--- a/src/app/(pages)/main/layouts/Header.tsx
+++ b/src/app/(pages)/main/layouts/Header.tsx
@@ -23,12 +23,7 @@ export function Header() {
   useEffect(() => {
     if (typeof window === "undefined") return
     const hasAccessToken = !!localStorage.getItem(ACCESS_TOKEN_KEY)
-    if (hasAccessToken) {
-      setIsLoggedIn(true)
-      return
-    }
-    const loggedFlag = localStorage.getItem("logged_in")
-    setIsLoggedIn(loggedFlag === "true")
+    setIsLoggedIn(hasAccessToken)
   }, [])
 
   return (

--- a/src/app/(pages)/main/layouts/Header.tsx
+++ b/src/app/(pages)/main/layouts/Header.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react"
 import { usePathname, useSearchParams } from "next/navigation"
 import Logo from "../assets/Logo.png"
 import { Button } from "../components/ui/button"
+import { ACCESS_TOKEN_KEY } from "@/lib/auth"
 
 export function Header() {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
@@ -20,15 +21,14 @@ export function Header() {
     "text-sm font-semibold cursor-pointer relative after:content-[''] after:absolute after:left-0 after:-bottom-1.5 after:h-[2px] after:bg-current after:transition-all after:duration-200"
 
   useEffect(() => {
-    if (typeof document === 'undefined') return
-    const match = document.cookie
-      .split(';')
-      .map((c) => c.trim())
-      .find((c) => c.startsWith('logged_in='))
-    if (match) {
-      const value = decodeURIComponent(match.split('=')[1] || '')
-      setIsLoggedIn(value === 'true')
+    if (typeof window === "undefined") return
+    const hasAccessToken = !!localStorage.getItem(ACCESS_TOKEN_KEY)
+    if (hasAccessToken) {
+      setIsLoggedIn(true)
+      return
     }
+    const loggedFlag = localStorage.getItem("logged_in")
+    setIsLoggedIn(loggedFlag === "true")
   }, [])
 
   return (

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,0 +1,78 @@
+import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY, clearTokens, getRefreshToken } from "./auth"
+
+const apiBase = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080"
+
+type ErrorResponse = {
+  detail?: string
+  type?: string
+  status?: number
+}
+
+export async function apiFetch(input: string, init?: RequestInit) {
+  const headers = new Headers(init?.headers || {})
+  const accessToken = typeof window !== "undefined" ? localStorage.getItem(ACCESS_TOKEN_KEY) : null
+  if (accessToken) {
+    headers.set("Authorization", `Bearer ${accessToken}`)
+  }
+
+  const doFetch = async () => {
+    const res = await fetch(`${apiBase}${input}`, { ...init, headers })
+    if (res.status !== 401) return res
+
+    // Try refresh on 401 with EXPIRED_TOKEN
+    let err: ErrorResponse | undefined
+    try {
+      err = (await res.clone().json()) as ErrorResponse
+    } catch {
+      // ignore parse failure
+    }
+
+    if (err?.type !== "EXPIRED_TOKEN") {
+      return res
+    }
+
+    const refreshed = await tryRefresh()
+    if (!refreshed) {
+      clearTokens()
+      return res
+    }
+
+    // retry original request with new access token
+    const retryHeaders = new Headers(headers)
+    const newAccess = localStorage.getItem(ACCESS_TOKEN_KEY)
+    if (newAccess) {
+      retryHeaders.set("Authorization", `Bearer ${newAccess}`)
+    }
+    return fetch(`${apiBase}${input}`, { ...init, headers: retryHeaders })
+  }
+
+  return doFetch()
+}
+
+async function tryRefresh() {
+  if (typeof window === "undefined") return false
+  const refreshToken = getRefreshToken()
+  if (!refreshToken) return false
+
+  try {
+    const res = await fetch(`${apiBase}/v1/auth/token/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+    })
+
+    if (!res.ok) {
+      clearTokens()
+      return false
+    }
+
+    const data = (await res.json()) as { accessToken?: string; refreshToken?: string }
+    if (data.accessToken) localStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken)
+    if (data.refreshToken) localStorage.setItem(REFRESH_TOKEN_KEY, data.refreshToken)
+    return true
+  } catch (err) {
+    console.error("Refresh token failed", err)
+    clearTokens()
+    return false
+  }
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,19 @@
+export const ACCESS_TOKEN_KEY = "accessToken"
+export const REFRESH_TOKEN_KEY = "refreshToken"
+
+export function getAccessToken() {
+  if (typeof window === "undefined") return null
+  return localStorage.getItem(ACCESS_TOKEN_KEY)
+}
+
+export function getRefreshToken() {
+  if (typeof window === "undefined") return null
+  return localStorage.getItem(REFRESH_TOKEN_KEY)
+}
+
+export function clearTokens() {
+  if (typeof window === "undefined") return
+  localStorage.removeItem(ACCESS_TOKEN_KEY)
+  localStorage.removeItem(REFRESH_TOKEN_KEY)
+  localStorage.removeItem("logged_in")
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,5 +15,4 @@ export function clearTokens() {
   if (typeof window === "undefined") return
   localStorage.removeItem(ACCESS_TOKEN_KEY)
   localStorage.removeItem(REFRESH_TOKEN_KEY)
-  localStorage.removeItem("logged_in")
 }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 로그인 폼을 실제 `/v1/auth/token/login` API와 연동해 JWT 발급 및 에러 처리 추가
- 공통 API 클라이언트로 401+EXPIRED_TOKEN 시 `/v1/auth/token/refresh` 재발급 후 재시도 로직 도입
- 헤더의 로그인 상태 표시를 쿠키 대신 localStorage 토큰 기반으로 전환해 마이페이지 버튼 토글


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 로그인 시 아이디/비밀번호를 검증하고, 성공 시 accessToken/refreshToken을 localStorage에 저장, 로딩/에러 UI 처리
- apiFetch 유틸 생성: Authorization 헤더 주입, 토큰 만료(401+EXPIRED_TOKEN) 시 리프레시 요청 후 원 요청 재시도, 실패 시 토큰 정리
- auth/main 헤더에서 쿠키 검사 로직 제거, accessToken 존재 여부로 로그인 상태 판단하여 버튼 전환
- close: #16 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

**로그인 API 연동**
|   제목   | 화면 캡처 |
| ------- | -------- |
| 로그인 성공 | ![login_success-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/2d18c302-5463-4b46-8e14-1a7ae1a2662d) |
| JWT<br>토큰 저장 | <img width="1000" alt="image" src="https://github.com/user-attachments/assets/0a0531a4-8123-41ab-86bf-7abc983b5bc6" /> |
| 로그인<br>전후 헤더 | <img width="1000" alt="image" src="https://github.com/user-attachments/assets/ecf853f5-f9ee-4181-b207-c316e5be6fda" /> <img width="1000" height="247" alt="image" src="https://github.com/user-attachments/assets/a4dba888-d280-45ed-b8f2-1e93b5134fa8" /> |
| ID <br>미존재 | <img width="1000" alt="image" src="https://github.com/user-attachments/assets/b79baff5-1b8e-4cf4-8fe2-1902cb1d832e" /> |
| PW<br>불일치 | <img width="1000" alt="image" src="https://github.com/user-attachments/assets/f3181b0b-c8ea-4a63-b298-257dd9c7114d" /> |



