### PR TITLE
[#20] setting: 프론트엔드 CI/CD 파이프라인 구성

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,86 @@
+name: Frontend CI/CD (ECR, Next.js)
+
+on:
+  push:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: ipiece-frontend   # 👉 ECR 리포 이름과 동일하게
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Enable corepack (pnpm)
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run build
+        run: pnpm build
+
+      # ==== AWS / ECR ====
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          echo "Registry: $ECR_REGISTRY"
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+      # ==== GitOps: manifests 레포 이미지 태그 업데이트 ====
+      - name: Update manifests repo with new frontend image tag
+        env:
+          GIT_TOKEN: ${{ secrets.MANIFESTS_REPO_TOKEN }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          git config --global user.email "ci@ipiece.local"
+          git config --global user.name "ipiece-ci"
+
+          # 매니페스트 레포 클론
+          git clone https://x-access-token:${GIT_TOKEN}@github.com/kohtaewoo/ipiece-manifests-test.git
+
+          cd ipiece-manifests-test/frontend
+
+          echo "Before change:"
+          grep "image:" deployment.yaml || true
+
+          # deployment.yaml 안 image 태그를 이번 SHA로 교체
+          sed -i "s#image: 235625001959.dkr.ecr.ap-northeast-2.amazonaws.com/ipiece-frontend:.*#image: 235625001959.dkr.ecr.ap-northeast-2.amazonaws.com/ipiece-frontend:${IMAGE_TAG}#" deployment.yaml
+
+          echo "After change:"
+          grep "image:" deployment.yaml || true
+
+          if git diff --quiet; then
+            echo "No changes to commit in manifests repo."
+          else
+            git commit -am "chore: update frontend image to ${IMAGE_TAG}"
+            git push
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# 1단계: 빌드
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+# pnpm 사용
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm build
+
+# 2단계: 실행
+FROM node:20-alpine
+WORKDIR /app
+
+RUN corepack enable
+ENV NODE_ENV=production
+
+COPY --from=builder /app ./
+
+EXPOSE 3000
+CMD ["pnpm", "start"]


### PR DESCRIPTION
## 📌 Summary
프론트엔드 ECR 푸시 및 GitOps 자동 반영을 위한 CI/CD 파이프라인 구성

## ✍️ Description
- Dockerfile 작성 (pnpm 기반 2단계 빌드)
- `.github/workflows/frontend-ci.yml` 추가
- GitHub Actions로 ECR에 이미지 빌드/푸시
- manifests 레포지토리(`ipiece-manifests-test/frontend`)에 자동 이미지 태그 업데이트

## 💡 PR Point
- 백엔드와 동일한 GitOps 패턴 적용
- ArgoCD가 프론트 배포 자동 반영하도록 구성
- Secrets는 `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `MANIFESTS_REPO_TOKEN` 필요

## 📚 Reference
- AWS ECR: 235625001959.dkr.ecr.ap-northeast-2.amazonaws.com/ipiece-frontend

## 🔥 Test
- `Actions` 탭에서 빌드 성공 확인
- ECR 이미지 생성 여부 확인
- manifests repo 자동 커밋/푸시 로그 확인