### PR TITLE
[#19] feat: 2차거래 페이지 API 연동

### DIFF
--- a/src/app/(pages)/layout.tsx
+++ b/src/app/(pages)/layout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react"
+import { Suspense } from "react"
 
 import { PageShell } from "./components/PageShell"
 
@@ -7,5 +8,9 @@ type PagesLayoutProps = {
 }
 
 export default function PagesLayout({ children }: PagesLayoutProps) {
-  return <PageShell>{children}</PageShell>
+  return (
+    <Suspense fallback={null}>
+      <PageShell>{children}</PageShell>
+    </Suspense>
+  )
 }

--- a/src/app/(pages)/main/MainClient.tsx
+++ b/src/app/(pages)/main/MainClient.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { Suspense } from 'react'
+import { HeroBanner } from './components/HeroBanner'
+import { MarketCard } from './components/MarketCard'
+import type { Item, Banner } from './constants/data'
+import { SAMPLE_BANNERS, SAMPLE_OFFERING, SAMPLE_TRADING } from './constants/data'
+import iconMore from './assets/icon_more.png'
+
+export default function MainClient() {
+  const offering: Item[] = SAMPLE_OFFERING
+  const trading: Item[] = SAMPLE_TRADING
+  const banners: Banner[] = SAMPLE_BANNERS
+
+  return (
+    <main className="text-[14px]">
+      <HeroBanner banners={banners} />
+      <div className="container mx-auto px-8 sm:px-12 lg:px-16 xl:px-20 py-12">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 lg:gap-12">
+          <div>
+            <div className="flex items-center justify-between mb-6">
+              <h2 className="text-[18px] font-bold">공모 중</h2>
+              <Link
+                href="/offering"
+                className="inline-flex items-center gap-1 text-[12px] text-gray-600 hover:text-gray-900 cursor-pointer"
+              >
+                더보기 <Image src={iconMore} alt="" width={12} height={12} className="h-3 w-3" />
+              </Link>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              {offering.slice(0, 4).map((item) => (
+                <MarketCard key={item.id} item={item} />
+              ))}
+            </div>
+          </div>
+          <div>
+            <div className="flex items-center justify-between mb-6">
+              <h2 className="text-[18px] font-bold">거래 중</h2>
+              <Link
+                href="/trading"
+                className="inline-flex items-center gap-1 text-[12px] text-gray-600 hover:text-gray-900 cursor-pointer"
+              >
+                더보기 <Image src={iconMore} alt="" width={12} height={12} className="h-3 w-3" />
+              </Link>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              {trading.slice(0, 4).map((item) => (
+                <MarketCard key={item.id} item={item} />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/(pages)/main/page.tsx
+++ b/src/app/(pages)/main/page.tsx
@@ -1,49 +1,10 @@
-import Image from "next/image"
-import Link from "next/link"
-import { HeroBanner } from "./components/HeroBanner"
-import { MarketCard } from "./components/MarketCard"
-import type { Item, Banner } from "./constants/data"
-import { SAMPLE_BANNERS, SAMPLE_OFFERING, SAMPLE_TRADING } from "./constants/data"
-import iconMore from "./assets/icon_more.png"
+import { Suspense } from "react"
+import MainClient from "./MainClient"
 
 export default function Home() {
-  const offering: Item[] = SAMPLE_OFFERING
-  const trading: Item[] = SAMPLE_TRADING
-  const banners: Banner[] = SAMPLE_BANNERS
-
   return (
-    <main className="text-[14px]">
-      <HeroBanner banners={banners} />
-      <div className="container mx-auto px-8 sm:px-12 lg:px-16 xl:px-20 py-12">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 lg:gap-12">
-          <div>
-            <div className="flex items-center justify-between mb-6">
-              <h2 className="text-[18px] font-bold">{'\uACF5\uBAA8 \uC911'}</h2>
-              <Link href="/offering" className="inline-flex items-center gap-1 text-[12px] text-gray-600 hover:text-gray-900 cursor-pointer">
-                {'\uB354\uBCF4\uAE30'} <Image src={iconMore} alt="" width={12} height={12} className="h-3 w-3" />
-              </Link>
-            </div>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-              {offering.slice(0, 4).map((item) => (
-                <MarketCard key={item.id} item={item} />
-              ))}
-            </div>
-          </div>
-          <div>
-            <div className="flex items-center justify-between mb-6">
-              <h2 className="text-[18px] font-bold">{'\uAC70\uB798 \uC911'}</h2>
-              <Link href="/trading" className="inline-flex items-center gap-1 text-[12px] text-gray-600 hover:text-gray-900 cursor-pointer">
-                {'\uB354\uBCF4\uAE30'} <Image src={iconMore} alt="" width={12} height={12} className="h-3 w-3" />
-              </Link>
-            </div>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-              {trading.slice(0, 4).map((item) => (
-                <MarketCard key={item.id} item={item} />
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-    </main>
+    <Suspense fallback={null}>
+      <MainClient />
+    </Suspense>
   )
 }

--- a/src/app/(pages)/offering/components/ui/command.tsx
+++ b/src/app/(pages)/offering/components/ui/command.tsx
@@ -34,13 +34,11 @@ function CommandDialog({
   description = 'Search for a command to run...',
   children,
   className,
-  showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof Dialog> & {
   title?: string
   description?: string
   className?: string
-  showCloseButton?: boolean
 }) {
   return (
     <Dialog {...props}>
@@ -48,10 +46,7 @@ function CommandDialog({
         <DialogTitle>{title}</DialogTitle>
         <DialogDescription>{description}</DialogDescription>
       </DialogHeader>
-      <DialogContent
-        className={cn('overflow-hidden p-0', className)}
-        showCloseButton={showCloseButton}
-      >
+      <DialogContent className={cn('overflow-hidden p-0', className)}>
         <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>
@@ -182,5 +177,4 @@ export {
   CommandShortcut,
   CommandSeparator,
 }
-
 

--- a/src/app/(pages)/trading/[id]/page.tsx
+++ b/src/app/(pages)/trading/[id]/page.tsx
@@ -112,6 +112,7 @@ export default function TradingDetailPage() {
     height: 0,
   });
 
+
   const updateHighlightPosition = () => {
     const container = tabContainerRef.current;
     const activeButton = tabRefs.current[activeTab];
@@ -298,8 +299,14 @@ export default function TradingDetailPage() {
       : 'text-[#3386E5]';
 
   const infoForCards: SecurityInfo = mappedInfo ?? MOCK_INFO;
+  const fallbackThumbnail = 'https://via.placeholder.com/64x64.png?text=IP';
+  const [thumbnailSrc, setThumbnailSrc] = useState(fallbackThumbnail);
 
-  const thumbnailSrc = productInfo?.thumbnail_img || infoForCards.heroImage;
+  useEffect(() => {
+    const candidate = productInfo?.thumbnail_img || infoForCards.heroImage || '';
+    const nextSrc = candidate.trim().length > 0 ? candidate : fallbackThumbnail;
+    setThumbnailSrc(nextSrc);
+  }, [productInfo?.thumbnail_img, infoForCards.heroImage]);
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -308,14 +315,10 @@ export default function TradingDetailPage() {
         <div className="mx-auto w-full max-w-[1560px] px-4 sm:px-8 lg:px-16 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <div className="w-12 h-12 rounded-lg overflow-hidden bg-gray-100" suppressHydrationWarning>
+              <div className="w-12 h-12 rounded-lg overflow-hidden bg-gray-100">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
-                  src={
-                    thumbnailSrc && thumbnailSrc.trim().length > 0
-                      ? thumbnailSrc
-                      : 'https://via.placeholder.com/64x64.png?text=IP'
-                  }
+                  src={thumbnailSrc}
                   alt={`${productInfo?.product_name ?? infoForCards.name} 썸네일`}
                   className="h-full w-full object-cover"
                 />
@@ -411,7 +414,11 @@ export default function TradingDetailPage() {
 
             {/* Order Form - Middle Column */}
             <div className="lg:h-[var(--panel-height)] lg:w-[320px]">
-              <OrderForm currentPrice={productInfo?.current_price ?? 0} assetSummary={assetSummary} />
+              <OrderForm
+                currentPrice={productInfo?.current_price ?? 0}
+                assetSummary={assetSummary}
+                productId={productInfo?.product_id ?? Number(id)}
+              />
             </div>
 
             {/* Order Book - Right Column */}

--- a/src/app/(pages)/trading/[id]/page.tsx
+++ b/src/app/(pages)/trading/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, useMemo } from 'react';
 import { useParams } from 'next/navigation';
 import { TradingChart } from '@/components/trade/chart/chart';
 import { OrderForm } from '@/components/trade/chart/order-form';
+import type { AssetSummary as OrderAssetSummary } from '@/components/trade/chart/order-form';
 import { OrderBook } from '@/components/trade/chart/orderbook';
 import {
   RevenueInfoCard,
@@ -53,6 +54,15 @@ type ProductDetailResponse = {
   details: ProductDetails;
 };
 
+type AssetResponse = {
+  product_name: string;
+  quantity: number;
+  avg_buy_price: number;
+  total_amount: number;
+  total_profit_amount: number;
+  total_profit_rate: number;
+};
+
 export default function TradingDetailPage() {
   const params = useParams();
   const id = params.id as string;
@@ -61,6 +71,7 @@ export default function TradingDetailPage() {
   const [productInfo, setProductInfo] = useState<ProductInfo | null>(null);
   const [productDetails, setProductDetails] = useState<ProductDetails | null>(null);
   const [notices, setNotices] = useState<Notice[] | undefined>(undefined);
+  const [assetSummary, setAssetSummary] = useState<OrderAssetSummary | null>(null);
   const tabContainerRef = useRef<HTMLDivElement>(null);
   const tabRefs = useRef<Record<'chart' | 'info', HTMLButtonElement | null>>({
     chart: null,
@@ -138,6 +149,33 @@ export default function TradingDetailPage() {
     };
 
     fetchDetails();
+  }, [id]);
+
+  useEffect(() => {
+    const fetchAsset = async () => {
+      try {
+        const res = await apiFetch(`/v1/market/${id}/asset`);
+        if (!res.ok) {
+          console.warn(`Failed to load asset summary: ${res.status}`);
+          setAssetSummary(null);
+          return;
+        }
+        const data = (await res.json()) as AssetResponse;
+        setAssetSummary({
+          productName: data.product_name,
+          quantity: data.quantity,
+          avgBuyPrice: data.avg_buy_price,
+          totalAmount: data.total_amount,
+          totalProfitAmount: data.total_profit_amount,
+          totalProfitRate: data.total_profit_rate,
+        });
+      } catch (error) {
+        console.error('Failed to fetch asset summary', error);
+        setAssetSummary(null);
+      }
+    };
+
+    fetchAsset();
   }, [id]);
 
   const mappedInfo = useMemo<SecurityInfo | null>(() => {
@@ -297,7 +335,7 @@ export default function TradingDetailPage() {
 
             {/* Order Form - Middle Column */}
             <div className="lg:h-[var(--panel-height)] lg:w-[320px]">
-              <OrderForm currentPrice={productInfo?.current_price ?? 0} />
+              <OrderForm currentPrice={productInfo?.current_price ?? 0} assetSummary={assetSummary} />
             </div>
 
             {/* Order Book - Right Column */}

--- a/src/app/(pages)/trading/[id]/page.tsx
+++ b/src/app/(pages)/trading/[id]/page.tsx
@@ -6,6 +6,7 @@ import { TradingChart } from '@/components/trade/chart/chart';
 import { OrderForm } from '@/components/trade/chart/order-form';
 import type { AssetSummary as OrderAssetSummary } from '@/components/trade/chart/order-form';
 import { OrderBook } from '@/components/trade/chart/orderbook';
+import type { OrderBookProps } from '@/components/trade/chart/orderbook';
 import {
   RevenueInfoCard,
   IpIntroCard,
@@ -63,6 +64,29 @@ type AssetResponse = {
   total_profit_rate: number;
 };
 
+type OrdersResponse = {
+  summary: {
+    highest_price: number;
+    lowest_price: number;
+    last_price: number;
+    price_change: number;
+    limit_up_price: number;
+    limit_down_price: number;
+    this_week_volume: number;
+    last_week_volume: number;
+  };
+  orders_sell: Array<{
+    order_price: number;
+    quantity: number;
+    price_change: number;
+  }>;
+  orders_buy: Array<{
+    order_price: number;
+    quantity: number;
+    price_change: number;
+  }>;
+};
+
 export default function TradingDetailPage() {
   const params = useParams();
   const id = params.id as string;
@@ -72,6 +96,7 @@ export default function TradingDetailPage() {
   const [productDetails, setProductDetails] = useState<ProductDetails | null>(null);
   const [notices, setNotices] = useState<Notice[] | undefined>(undefined);
   const [assetSummary, setAssetSummary] = useState<OrderAssetSummary | null>(null);
+  const [orderBookData, setOrderBookData] = useState<OrderBookProps | null>(null);
   const tabContainerRef = useRef<HTMLDivElement>(null);
   const tabRefs = useRef<Record<'chart' | 'info', HTMLButtonElement | null>>({
     chart: null,
@@ -178,6 +203,46 @@ export default function TradingDetailPage() {
     fetchAsset();
   }, [id]);
 
+  useEffect(() => {
+    const fetchOrders = async () => {
+      try {
+        const res = await apiFetch(`/v1/market/${id}/orders`);
+        if (!res.ok) {
+          console.warn(`Failed to load order book: ${res.status}`);
+          setOrderBookData(null);
+          return;
+        }
+        const data = (await res.json()) as OrdersResponse;
+        const mapOrders = (orders: OrdersResponse['orders_sell']) =>
+          orders?.map((order) => ({
+            price: order.order_price,
+            quantity: order.quantity,
+            changePct: order.price_change,
+          })) ?? [];
+
+        setOrderBookData({
+          summary: {
+            highestPrice: data.summary?.highest_price ?? 0,
+            lowestPrice: data.summary?.lowest_price ?? 0,
+            lastPrice: data.summary?.last_price ?? 0,
+            priceChange: data.summary?.price_change ?? 0,
+            limitUpPrice: data.summary?.limit_up_price ?? 0,
+            limitDownPrice: data.summary?.limit_down_price ?? 0,
+            thisWeekVolume: data.summary?.this_week_volume ?? 0,
+            lastWeekVolume: data.summary?.last_week_volume ?? 0,
+          },
+          ordersSell: mapOrders(data.orders_sell ?? []),
+          ordersBuy: mapOrders(data.orders_buy ?? []),
+        });
+      } catch (error) {
+        console.error('Failed to fetch order book data', error);
+        setOrderBookData(null);
+      }
+    };
+
+    fetchOrders();
+  }, [id]);
+
   const mappedInfo = useMemo<SecurityInfo | null>(() => {
     if (!productInfo || !productDetails) return null;
 
@@ -234,6 +299,8 @@ export default function TradingDetailPage() {
 
   const infoForCards: SecurityInfo = mappedInfo ?? MOCK_INFO;
 
+  const thumbnailSrc = productInfo?.thumbnail_img || infoForCards.heroImage;
+
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
@@ -241,8 +308,17 @@ export default function TradingDetailPage() {
         <div className="mx-auto w-full max-w-[1560px] px-4 sm:px-8 lg:px-16 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <div className="w-12 h-12 bg-gray-200 rounded-lg flex items-center justify-center text-xs text-gray-500">
-                logo
+              <div className="w-12 h-12 rounded-lg overflow-hidden bg-gray-100" suppressHydrationWarning>
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={
+                    thumbnailSrc && thumbnailSrc.trim().length > 0
+                      ? thumbnailSrc
+                      : 'https://via.placeholder.com/64x64.png?text=IP'
+                  }
+                  alt={`${productInfo?.product_name ?? infoForCards.name} 썸네일`}
+                  className="h-full w-full object-cover"
+                />
               </div>
               <div>
                 <h1 className="text-xl font-bold">
@@ -340,7 +416,11 @@ export default function TradingDetailPage() {
 
             {/* Order Book - Right Column */}
             <div className="lg:h-[var(--panel-height)]">
-              <OrderBook />
+              <OrderBook
+                summary={orderBookData?.summary}
+                ordersSell={orderBookData?.ordersSell}
+                ordersBuy={orderBookData?.ordersBuy}
+              />
             </div>
           </div>
         </main>

--- a/src/app/(pages)/trading/[id]/page.tsx
+++ b/src/app/(pages)/trading/[id]/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useMemo } from 'react';
 import { useParams } from 'next/navigation';
-import { Card, CardContent } from '@/components/ui/card';
 import { TradingChart } from '@/components/trade/chart/chart';
 import { OrderForm } from '@/components/trade/chart/order-form';
 import { OrderBook } from '@/components/trade/chart/orderbook';
@@ -12,15 +11,56 @@ import {
 } from '@/components/trade/info/info-panel';
 import { ImageInfoPanel } from '@/components/trade/info/image-info-panel';
 import { NoticePanel } from '@/components/trade/info/notice-panel';
+import type { Notice, SecurityInfo } from '@/lib/mock-info';
 import { MOCK_INFO } from '@/lib/mock-info';
-import { MOCK_ITEMS } from '@/lib/mock-trading';
 import { buildHeartMaskStyle } from '@/components/common/heart-mask-style';
+import { apiFetch } from '@/lib/api-client';
+
+type ProductInfo = {
+  product_id: number;
+  product_name: string;
+  token_unit: string;
+  current_price: number;
+  change_rate: number;
+  thumbnail_img: string;
+  is_favorited: boolean;
+};
+
+type ProductNotice = {
+  disclosure_date: string;
+  disclosure_title: string;
+  disclosure_url?: string;
+};
+
+type ProductDetails = {
+  owner: string;
+  total_supply: number;
+  token_standard: string;
+  exchange_listing: string;
+  description: string;
+  detail_image?: string;
+  detail_url?: string;
+  dividends?: {
+    dividend_id: number;
+    amount_per_token: number;
+    payment_date: string;
+  }[];
+  notices?: ProductNotice[];
+};
+
+type ProductDetailResponse = {
+  info: ProductInfo;
+  details: ProductDetails;
+};
 
 export default function TradingDetailPage() {
   const params = useParams();
   const id = params.id as string;
   const [liked, setLiked] = useState(false);
   const [activeTab, setActiveTab] = useState<'chart' | 'info'>('chart');
+  const [productInfo, setProductInfo] = useState<ProductInfo | null>(null);
+  const [productDetails, setProductDetails] = useState<ProductDetails | null>(null);
+  const [notices, setNotices] = useState<Notice[] | undefined>(undefined);
   const tabContainerRef = useRef<HTMLDivElement>(null);
   const tabRefs = useRef<Record<'chart' | 'info', HTMLButtonElement | null>>({
     chart: null,
@@ -64,12 +104,97 @@ export default function TradingDetailPage() {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  // Find the item from mock data
-  const item = MOCK_ITEMS.find((i) => i.id === id) || MOCK_ITEMS[0];
+  useEffect(() => {
+    const fetchDetails = async () => {
+      try {
+        const res = await apiFetch(`/v1/market/${id}/details`);
+        if (!res.ok) {
+          throw new Error(`Failed to load product details: ${res.status}`);
+        }
 
-  const changePct = item.changePct;
-  const isPositive = changePct >= 0;
-  const changeText = isPositive ? `+${changePct}%` : `${changePct}%`;
+        const data = (await res.json()) as ProductDetailResponse;
+        setProductInfo(data.info);
+        setProductDetails(data.details);
+        setLiked(Boolean(data.info?.is_favorited));
+
+        const mappedNotices: Notice[] | undefined = data.details?.notices?.map(
+          (notice, idx) => {
+            const date = notice.disclosure_date;
+            const year = new Date(date).getFullYear();
+            return {
+              id: `notice-${idx}-${date}`,
+              date,
+              title: notice.disclosure_title,
+              subtitle: undefined,
+              year,
+              url: notice.disclosure_url,
+            } satisfies Notice;
+          },
+        );
+        setNotices(mappedNotices);
+      } catch (error) {
+        console.error('Failed to fetch product details', error);
+      }
+    };
+
+    fetchDetails();
+  }, [id]);
+
+  const mappedInfo = useMemo<SecurityInfo | null>(() => {
+    if (!productInfo || !productDetails) return null;
+
+    const dividends = productDetails.dividends ?? [];
+    const revenueMonthly = dividends
+      .map((dividend) => {
+        const date = new Date(dividend.payment_date);
+        const monthLabel = `${date.getMonth() + 1}월`;
+        return {
+          t: monthLabel,
+          value: dividend.amount_per_token,
+          date: dividend.payment_date,
+        };
+      })
+      .sort((a, b) => {
+        const aMonth = Number(a.t.replace('월', ''));
+        const bMonth = Number(b.t.replace('월', ''));
+        return aMonth - bMonth;
+      });
+
+    return {
+      id: String(productInfo.product_id ?? id),
+      name: productInfo.product_name,
+      issueDate: '',
+      publisher: productDetails.owner ?? '',
+      totalIssue: productDetails.total_supply
+        ? productDetails.total_supply.toLocaleString('ko-KR')
+        : '',
+      tokenStandard: productDetails.token_standard ?? '',
+      listing: productDetails.exchange_listing ?? '',
+      summary: productDetails.description ?? '',
+      heroImage:
+        productDetails.detail_image ||
+        productDetails.detail_url ||
+        productInfo.thumbnail_img,
+      revenueMonthly,
+    };
+  }, [id, productDetails, productInfo]);
+
+  const changeRate = Number(productInfo?.change_rate ?? 0);
+  const formattedChange = changeRate.toFixed(1);
+  const isZeroChange = changeRate === 0;
+  const isPositiveChange = changeRate > 0;
+  const changeText = isZeroChange
+    ? '0.0%'
+    : isPositiveChange
+      ? `+${formattedChange}%`
+      : `${formattedChange}%`;
+  const changeClass = isZeroChange
+    ? 'text-gray-500'
+    : isPositiveChange
+      ? 'text-[#E53333]'
+      : 'text-[#3386E5]';
+
+  const infoForCards: SecurityInfo = mappedInfo ?? MOCK_INFO;
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -82,10 +207,16 @@ export default function TradingDetailPage() {
                 logo
               </div>
               <div>
-                <h1 className="text-xl font-bold">{item.title}</h1>
-                <p className="text-sm text-gray-600">
-                  1 Dino Tokens 당 {item.priceKRW.toLocaleString('ko-KR')}원{' '}
-                  <span className="text-[#E53333] font-medium">
+                <h1 className="text-xl font-bold">
+                  {productInfo?.product_name ?? infoForCards.name}
+                </h1>
+                <p className="text-sm text-gray-600" suppressHydrationWarning>
+                  1 {productInfo?.token_unit ?? ''} 당{' '}
+                  {productInfo?.current_price?.toLocaleString('ko-KR') ?? '-'}원{' '}
+                  <span
+                    className={`ml-2 ${changeClass} text-base font-semibold`}
+                    suppressHydrationWarning
+                  >
                     {changeText}
                   </span>
                 </p>
@@ -166,7 +297,7 @@ export default function TradingDetailPage() {
 
             {/* Order Form - Middle Column */}
             <div className="lg:h-[var(--panel-height)] lg:w-[320px]">
-              <OrderForm currentPrice={item.priceKRW} />
+              <OrderForm currentPrice={productInfo?.current_price ?? 0} />
             </div>
 
             {/* Order Book - Right Column */}
@@ -181,12 +312,12 @@ export default function TradingDetailPage() {
         <main className="mx-auto w-full max-w-[1680px] px-6 lg:px-12 py-6">
           <div className="space-y-8">
             <div className="grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,3fr)_minmax(320px,2fr)] items-start">
-              <RevenueInfoCard info={MOCK_INFO} />
-              <ImageInfoPanel info={MOCK_INFO} />
+              <RevenueInfoCard info={infoForCards} />
+              <ImageInfoPanel info={infoForCards} />
             </div>
             <div className="grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] items-start">
-              <IpIntroCard info={MOCK_INFO} />
-              <NoticePanel />
+              <IpIntroCard info={infoForCards} />
+              <NoticePanel notices={notices} />
             </div>
           </div>
         </main>

--- a/src/app/(pages)/trading/page.tsx
+++ b/src/app/(pages)/trading/page.tsx
@@ -1,42 +1,109 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 // TODO: 추푸 NavTabs, Footer ?�일 추�?
 // import { NavTabs } from '@/components/nav-tabs';
 import { TradeCard } from '@/components/trade/trade-card';
-import { sampleIPOData } from '@/lib/sample-data';
+import type { IPOItem } from '@/lib/sample-data';
+import { apiFetch } from '@/lib/api-client';
+
+type MarketProduct = {
+  productId: number;
+  thumbnailImg: string;
+  productName: string;
+  owner: string;
+  currentPrice: number;
+  changeRate: number;
+  isFavorited: boolean;
+  startAt: string;
+};
+
+type MarketProductsResponse = {
+  products: MarketProduct[];
+  totalCount: number;
+  page: number;
+};
+
+const mapProductToIPOItem = (product: MarketProduct): IPOItem => ({
+  id: `${product.productId}`,
+  title: product.productName,
+  author: product.owner,
+  priceKRW: product.currentPrice,
+  changePct: product.changeRate,
+  imageUrl: product.thumbnailImg,
+  liked: product.isFavorited,
+});
 
 export default function HomePage() {
-  const [allItems, setAllItems] = useState(() =>
-    sampleIPOData.map((item) => ({ ...item })),
-  );
-  const [displayedCount, setDisplayedCount] = useState(12);
+  const [items, setItems] = useState<IPOItem[]>([]);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const [totalCount, setTotalCount] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const sentinelRef = useRef<HTMLDivElement>(null);
+  const isRequestingRef = useRef(false);
 
-  const displayedItems = allItems.slice(0, displayedCount);
-  const hasMore = displayedCount < allItems.length;
+  const fetchProducts = useCallback(async (pageToFetch: number) => {
+    if (isRequestingRef.current) return;
 
-  const handleLikeToggle = (id: string) => {
-    setAllItems((items) =>
-      items.map((item) =>
-        item.id === id ? { ...item, liked: !item.liked } : item,
-      ),
-    );
-  };
+    isRequestingRef.current = true;
+    setIsLoading(true);
+    try {
+      const res = await apiFetch(`/v1/market/products?page=${pageToFetch}`);
+      if (!res.ok) {
+        throw new Error(`Failed to load products: ${res.status}`);
+      }
+
+      const data = (await res.json()) as MarketProductsResponse;
+      const mapped = Array.isArray(data.products)
+        ? data.products.map(mapProductToIPOItem)
+        : [];
+
+      let mergedLength = 0;
+      setItems((prev) => {
+        const existingIds = new Set(prev.map((item) => item.id));
+        const merged = [...prev];
+        mapped.forEach((item) => {
+          if (!existingIds.has(item.id)) {
+            merged.push(item);
+            existingIds.add(item.id);
+          }
+        });
+        mergedLength = merged.length;
+        return merged;
+      });
+
+      const total = typeof data.totalCount === 'number' ? data.totalCount : null;
+      setTotalCount((current) => (total !== null ? total : current));
+
+      const shouldLoadMore =
+        total !== null ? mapped.length > 0 && mergedLength < total : mapped.length > 0;
+      setHasMore(shouldLoadMore);
+      setPage(pageToFetch);
+    } catch (error) {
+      console.error('Failed to fetch products', error);
+    } finally {
+      setIsLoading(false);
+      isRequestingRef.current = false;
+    }
+  }, []);
+
+  const fetchNextPage = useCallback(() => {
+    if (!hasMore || isRequestingRef.current) return;
+    fetchProducts(page + 1);
+  }, [fetchProducts, hasMore, page]);
+
+  useEffect(() => {
+    fetchProducts(1);
+  }, [fetchProducts]);
 
   useEffect(() => {
     if (!sentinelRef.current || !hasMore) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting && !isLoading && hasMore) {
-          setIsLoading(true);
-          // Simulate loading delay
-          setTimeout(() => {
-            setDisplayedCount((prev) => Math.min(prev + 10, allItems.length));
-            setIsLoading(false);
-          }, 500);
+        if (entries[0].isIntersecting && !isRequestingRef.current && hasMore) {
+          fetchNextPage();
         }
       },
       { threshold: 0.1 },
@@ -45,19 +112,29 @@ export default function HomePage() {
     observer.observe(sentinelRef.current);
 
     return () => observer.disconnect();
-  }, [hasMore, isLoading, allItems.length]);
+  }, [hasMore, fetchNextPage]);
+
+  const handleLikeToggle = (id: string) => {
+    setItems((items) =>
+      items.map((item) =>
+        item.id === id ? { ...item, liked: !item.liked } : item,
+      ),
+    );
+  };
+
+  const totalItems = totalCount ?? items.length;
 
   return (
     <main className="flex-1 p-6 md:p-8">
       {/* <NavTabs /> */}
       <div className="mb-6">
         <span className="inline-flex items-center justify-center bg-gray-100 text-gray-900 font-medium px-3 py-1 rounded text-sm">
-          {allItems.length}개
+          {totalItems}개
         </span>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-        {displayedItems.map((item) => (
+        {items.map((item) => (
           <TradeCard
             key={item.id}
             item={item}
@@ -71,7 +148,7 @@ export default function HomePage() {
           {isLoading && (
             <div className="flex items-center gap-2 text-muted-foreground">
               <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-              <span>로딩 �?..</span>
+              <span>로딩 중...</span>
             </div>
           )}
         </div>

--- a/src/components/trade/chart/order-form.tsx
+++ b/src/components/trade/chart/order-form.tsx
@@ -5,12 +5,14 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { Card, CardContent } from '@/components/ui/card';
 import myHomeEmptyIcon from '@/assets/images/my_home_empty_state_icon.svg';
+import { apiFetch } from '@/lib/api-client';
 
 type OrderTab = 'buy' | 'sell' | 'pending';
 
 interface OrderFormProps {
   currentPrice: number;
   assetSummary: AssetSummary | null;
+  productId?: number | string;
 }
 
 export type AssetSummary = {
@@ -22,6 +24,20 @@ export type AssetSummary = {
   totalProfitRate: number;
 };
 
+type BuyOrderResponse = {
+  status_code?: number;
+  order_id?: string;
+  product_id?: number;
+  side?: string;
+  order_price?: number;
+  order_quantity?: number;
+  total_amount?: number;
+  filled_quantity?: number;
+  remaining_quantity?: number;
+  created_at?: string;
+  idempotency_key?: string;
+};
+
 type PendingOrder = {
   id: string;
   side: Exclude<OrderTab, 'pending'>;
@@ -30,38 +46,129 @@ type PendingOrder = {
   createdAt: number;
 };
 
-export function OrderForm({ currentPrice, assetSummary }: OrderFormProps) {
+type PendingOrderResponse = {
+  page?: number;
+  content?: Array<{
+    order_id: string;
+    side: 'buy' | 'sell';
+    order_price: number;
+    order_quantity: number;
+    created_at: string;
+  }>;
+};
+
+export function OrderForm({ currentPrice, assetSummary, productId }: OrderFormProps) {
   const [activeTab, setActiveTab] = useState<OrderTab>('buy');
-  const [orderType] = useState('limit');
   const [price, setPrice] = useState(currentPrice);
   const [quantity, setQuantity] = useState(1);
   const [pendingOrders, setPendingOrders] = useState<PendingOrder[]>([]);
   const [hasHydrated, setHasHydrated] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   useEffect(() => {
     setHasHydrated(true);
   }, []);
 
-  const handleSubmit = () => {
-    if (activeTab === 'pending') return;
+  useEffect(() => {
+    const fetchPendingOrders = async () => {
+      const numericProductId = Number(productId);
+      if (!Number.isFinite(numericProductId)) return;
 
-    const newOrder: PendingOrder = {
-      id: `${Date.now()}`,
-      side: activeTab,
-      price,
-      quantity,
-      createdAt: Date.now(),
+      try {
+        const res = await apiFetch(`/v1/market/${numericProductId}/orderbook/status=pending`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ page: 1 }),
+        });
+        if (!res.ok) {
+          console.warn(`Failed to load pending orders: ${res.status}`);
+          return;
+        }
+        const data = (await res.json()) as PendingOrderResponse;
+        const normalized = data.content?.map((order) => ({
+          id: order.order_id,
+          side: order.side,
+          price: order.order_price,
+          quantity: order.order_quantity,
+          createdAt: Date.parse(order.created_at) || Date.now(),
+        })) ?? [];
+        setPendingOrders(normalized);
+      } catch (error) {
+        console.error('Failed to fetch pending orders', error);
+      }
     };
 
-    setPendingOrders((prev) => [newOrder, ...prev]);
-    console.log('[v0] Order queued:', {
-      ...newOrder,
-      orderType,
-      total: newOrder.price * newOrder.quantity,
-    });
+    fetchPendingOrders();
+  }, [productId]);
 
-    setPrevTab(activeTab);
-    setActiveTab('pending');
+  const handleSubmit = async () => {
+    if (activeTab === 'pending' || isSubmitting) return;
+
+    const numericProductId = Number(productId);
+    if (!Number.isFinite(numericProductId)) {
+      setSubmitError('상품 정보를 불러오는 중입니다. 잠시 후 다시 시도해주세요.');
+      return;
+    }
+
+    const payload = {
+      order_price: price,
+      order_quantity: quantity,
+      client_time: new Date().toISOString(),
+    };
+
+    const idempotencyKey =
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+    const endpoint = activeTab === 'sell' ? 'sell' : 'buy';
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      const res = await apiFetch(`/v1/market/${numericProductId}/${endpoint}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Idempotency-Key': idempotencyKey,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const actionLabel = activeTab === 'sell' ? '판매' : '구매';
+        let errMsg = `${actionLabel} 주문에 실패했습니다. (코드 ${res.status})`;
+        try {
+          const errorBody = (await res.json()) as { detail?: string };
+          if (errorBody?.detail) errMsg = errorBody.detail;
+        } catch {
+          // ignore
+        }
+        setSubmitError(errMsg);
+        return;
+      }
+
+      const data = (await res.json()) as BuyOrderResponse;
+      const createdAtTs = data.created_at ? Date.parse(data.created_at) : Date.now();
+      const newOrder: PendingOrder = {
+        id: data.order_id ?? `${Date.now()}`,
+        side: (data.side as PendingOrder['side']) ?? activeTab,
+        price: data.order_price ?? price,
+        quantity: data.order_quantity ?? quantity,
+        createdAt: Number.isNaN(createdAtTs) ? Date.now() : createdAtTs,
+      };
+
+      setPendingOrders((prev) => [newOrder, ...prev]);
+      setPrevTab(activeTab);
+      setActiveTab('pending');
+    } catch (error) {
+      console.error('Order failed', error);
+      setSubmitError('주문 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const incrementPrice = () => setPrice((p) => p + 100);
@@ -295,14 +402,18 @@ export function OrderForm({ currentPrice, assetSummary }: OrderFormProps) {
               <div className="mt-auto pt-4 pb-1">
                 <button
                   onClick={handleSubmit}
-                  className="w-full rounded-xl py-3 text-sm font-semibold text-white transition-colors"
+                  disabled={isSubmitting}
+                  className="w-full rounded-xl py-3 text-sm font-semibold text-white transition-colors disabled:opacity-70 disabled:cursor-not-allowed"
                   style={{
                     backgroundColor: tabStyles.accent,
                     boxShadow: `0 8px 16px -12px ${tabStyles.accent}`,
                   }}
                 >
-                  {tabStyles.buttonLabel}
+                  {isSubmitting ? '주문 중...' : tabStyles.buttonLabel}
                 </button>
+                {submitError ? (
+                  <p className="mt-2 text-xs text-red-500">{submitError}</p>
+                ) : null}
               </div>
             </div>
           )}

--- a/src/components/trade/chart/order-form.tsx
+++ b/src/components/trade/chart/order-form.tsx
@@ -4,20 +4,22 @@ import Image from 'next/image';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { Card, CardContent } from '@/components/ui/card';
-import emptyIcon from '@/assets/empty_icon.svg';
+import myHomeEmptyIcon from '@/assets/images/my_home_empty_state_icon.svg';
 
 type OrderTab = 'buy' | 'sell' | 'pending';
 
 interface OrderFormProps {
   currentPrice: number;
+  assetSummary: AssetSummary | null;
 }
 
-type OrderSummary = {
-  totalProfit: number;
-  profitRate: number;
-  totalAmount: number;
+export type AssetSummary = {
+  productName: string;
   quantity: number;
-  averagePrice: number;
+  avgBuyPrice: number;
+  totalAmount: number;
+  totalProfitAmount: number;
+  totalProfitRate: number;
 };
 
 type PendingOrder = {
@@ -28,19 +30,17 @@ type PendingOrder = {
   createdAt: number;
 };
 
-export function OrderForm({ currentPrice }: OrderFormProps) {
+export function OrderForm({ currentPrice, assetSummary }: OrderFormProps) {
   const [activeTab, setActiveTab] = useState<OrderTab>('buy');
   const [orderType] = useState('limit');
   const [price, setPrice] = useState(currentPrice);
   const [quantity, setQuantity] = useState(1);
-  const [myOrder] = useState<OrderSummary | null>({
-    totalProfit: 658_000,
-    profitRate: 0.719,
-    totalAmount: 1_572_000,
-    quantity: 15,
-    averagePrice: 60_933,
-  });
   const [pendingOrders, setPendingOrders] = useState<PendingOrder[]>([]);
+  const [hasHydrated, setHasHydrated] = useState(false);
+
+  useEffect(() => {
+    setHasHydrated(true);
+  }, []);
 
   const handleSubmit = () => {
     if (activeTab === 'pending') return;
@@ -69,10 +69,15 @@ export function OrderForm({ currentPrice }: OrderFormProps) {
   const incrementQuantity = () => setQuantity((q) => q + 1);
   const decrementQuantity = () => setQuantity((q) => Math.max(1, q - 1));
 
-  const formatCurrency = (value: number) =>
-    `${value.toLocaleString('ko-KR')}원`;
+  const formatCurrency = (value: number) => `${value.toLocaleString('ko-KR')}원`;
 
-  const formatRate = (value: number) => `${(value * 100).toFixed(1)}%`;
+  const formatProfitAmount = (value: number) => {
+    if (value === 0) return formatCurrency(0);
+    const sign = value > 0 ? '+' : '−';
+    return `${sign}${formatCurrency(Math.abs(value))}`;
+  };
+
+  const formatRate = (value: number) => `${value.toFixed(1)}%`;
   const formatTimestamp = (value: number) =>
     new Date(value).toLocaleString('ko-KR', {
       month: '2-digit',
@@ -399,18 +404,7 @@ export function OrderForm({ currentPrice }: OrderFormProps) {
       {/* My Orders Card */}
       <Card className="flex flex-1 flex-col rounded-2xl shadow-sm transition-shadow hover:shadow-md">
         <CardContent className="flex flex-col p-6 pb-4 pt-4">
-          {!myOrder ? (
-            <div className="flex flex-col items-center gap-3 py-6 text-sm text-gray-500">
-              <Image
-                src={emptyIcon}
-                alt="주문 없음"
-                width={88}
-                height={88}
-                priority
-              />
-              <p>아직 등록된 주문이 없어요.</p>
-            </div>
-          ) : (
+          {assetSummary ? (
             <div className="flex flex-col text-sm text-[#4B5563]">
               <div className="flex items-start justify-between pt-2">
                 <h3 className="text-base font-semibold text-[#111827]">
@@ -426,30 +420,54 @@ export function OrderForm({ currentPrice }: OrderFormProps) {
                   <dt className="text-sm font-medium text-[#111827]">
                     총 수익
                   </dt>
-                  <dd className="text-right text-base font-semibold text-[#E53333]">
-                    +{formatCurrency(myOrder.totalProfit)} (
-                    {formatRate(myOrder.profitRate)})
+                  <dd
+                    className={`text-right text-base font-semibold ${
+                      assetSummary.totalProfitAmount > 0
+                        ? 'text-[#E53333]'
+                        : assetSummary.totalProfitAmount < 0
+                          ? 'text-[#1D4ED8]'
+                          : 'text-[#6B7280]'
+                    }`}
+                  >
+                    {formatProfitAmount(assetSummary.totalProfitAmount)} (
+                    {formatRate(Number(assetSummary.totalProfitRate ?? 0))})
                   </dd>
                 </div>
                 <div className="grid grid-cols-[auto_auto] items-baseline gap-x-6 pt-[10px]">
                   <dt className="text-xs text-[#6B7280]">총 금액</dt>
                   <dd className="text-right text-sm font-medium text-[#6B7280]">
-                    {formatCurrency(myOrder.totalAmount)}
+                    {formatCurrency(assetSummary.totalAmount)}
                   </dd>
                 </div>
                 <div className="grid grid-cols-[auto_auto] items-baseline gap-x-6">
                   <dt className="text-xs text-[#6B7280]">수량</dt>
                   <dd className="text-right text-sm font-medium text-[#6B7280]">
-                    {myOrder.quantity.toLocaleString('ko-KR')}주
+                    {assetSummary.quantity.toLocaleString('ko-KR')}주
                   </dd>
                 </div>
                 <div className="grid grid-cols-[auto_auto] items-baseline gap-x-6">
                   <dt className="text-xs text-[#6B7280]">1주 평균 금액</dt>
                   <dd className="text-right text-sm font-medium text-[#6B7280]">
-                    {formatCurrency(myOrder.averagePrice)}
+                    {formatCurrency(assetSummary.avgBuyPrice)}
                   </dd>
                 </div>
               </dl>
+            </div>
+          ) : hasHydrated ? (
+            <div className="flex flex-col items-center gap-4 py-8 text-sm text-gray-500">
+              <Image
+                src={myHomeEmptyIcon}
+                alt="내 자산 정보 없음"
+                width={64}
+                height={64}
+                priority
+              />
+              <p className="mt-3 text-[#5A6A86]">내 자산 정보가 없습니다.</p>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center gap-4 py-8 text-sm text-gray-500">
+              <div className="h-12 w-12 rounded-full bg-gray-200" />
+              <div className="h-3 w-24 rounded-full bg-gray-100" />
             </div>
           )}
         </CardContent>

--- a/src/components/trade/chart/orderbook.tsx
+++ b/src/components/trade/chart/orderbook.tsx
@@ -1,39 +1,36 @@
 'use client';
 
-import { useMemo, useState } from 'react';
-
 import { Card, CardContent } from '@/components/ui/card';
-import { ORDERBOOK, SUMMARY_STATS } from '@/lib/mock-trading';
 
-type ActiveSide = 'sell' | 'buy';
+export type OrderBookSummary = {
+  highestPrice: number;
+  lowestPrice: number;
+  lastPrice: number;
+  priceChange: number;
+  limitUpPrice: number;
+  limitDownPrice: number;
+  thisWeekVolume: number;
+  lastWeekVolume: number;
+};
 
-export function OrderBook() {
-  const [activeSide, setActiveSide] = useState<ActiveSide>('sell');
+export type OrderBookEntry = {
+  price: number;
+  quantity: number;
+  changePct: number;
+};
 
-  const askRows = useMemo(
-    () =>
-      ORDERBOOK.filter(
-        (row) => typeof row.askQty === 'number' && row.askQty > 0,
-      ),
-    [],
-  );
-  const bidRows = useMemo(
-    () =>
-      ORDERBOOK.filter(
-        (row) => typeof row.bidQty === 'number' && row.bidQty > 0,
-      ),
-    [],
-  );
+export interface OrderBookProps {
+  summary?: OrderBookSummary | null;
+  ordersSell?: OrderBookEntry[];
+  ordersBuy?: OrderBookEntry[];
+}
 
-  const totals = useMemo(
-    () => ({
-      sell: askRows.reduce((acc, row) => acc + (row.askQty ?? 0), 0),
-      buy: bidRows.reduce((acc, row) => acc + (row.bidQty ?? 0), 0),
-    }),
-    [askRows, bidRows],
-  );
-
+export function OrderBook({ summary, ordersSell = [], ordersBuy = [] }: OrderBookProps) {
+  const totalSell = ordersSell.reduce((acc, row) => acc + row.quantity, 0);
+  const totalBuy = ordersBuy.reduce((acc, row) => acc + row.quantity, 0);
   const formatNumber = (value: number) => value.toLocaleString('ko-KR');
+  const formatChange = (value: number) => `${value >= 0 ? '+' : ''}${value.toFixed(1)}%`;
+  const hasData = ordersSell.length > 0 || ordersBuy.length > 0;
 
   return (
     <Card className="flex h-full flex-col rounded-2xl shadow-sm transition-shadow hover:shadow-md">
@@ -43,42 +40,46 @@ export function OrderBook() {
           <div className="flex items-center gap-2 text-xs text-slate-500">
             <span>총 판매</span>
             <span className="font-semibold text-slate-700">
-              {formatNumber(totals.sell)}주
+              {formatNumber(totalSell)}주
             </span>
             <span className="mx-1 h-3 w-px bg-slate-200" />
             <span>총 구매</span>
             <span className="font-semibold text-slate-700">
-              {formatNumber(totals.buy)}주
+              {formatNumber(totalBuy)}주
             </span>
           </div>
         </div>
 
         <div className="flex flex-1 flex-col overflow-hidden rounded-2xl border bg-white/80">
-          <div className="grid grid-cols-3 border-b px-6 py-3 text-xs font-medium text-slate-500">
-            <span className="text-left">판매 수량</span>
-            <span className="text-center">가격</span>
-            <span className="text-right">구매 수량</span>
+          <div className="grid grid-cols-3 border-b px-6 py-3 text-xs font-medium text-slate-500 text-center">
+            <span>판매 수량</span>
+            <span>가격</span>
+            <span>구매 수량</span>
           </div>
 
           <div className="flex-1 space-y-2 overflow-y-auto px-4 py-2">
-            {askRows.map((row) => (
+            {!hasData && (
+              <div className="flex h-full items-center justify-center text-xs text-slate-400">
+                호가 데이터를 불러오는 중...
+              </div>
+            )}
+            {ordersSell.map((row) => (
               <div
                 key={`ask-${row.price}`}
-                className="grid grid-cols-3 items-center rounded-lg px-3 py-2 text-sm transition-colors hover:bg-[#F2F4F7]"
+                className="grid grid-cols-3 items-center rounded-lg px-3 py-4 text-sm transition-colors hover:bg-[#F2F4F7] text-center"
               >
-                <span className="pl-4 text-left font-semibold text-[#2563EB]">
-                  {formatNumber(row.askQty!)}
+                <span className="font-semibold text-[#2563EB]">
+                  {formatNumber(row.quantity)}
                 </span>
                 <span className="flex items-center justify-center gap-2">
                   <span className="font-semibold text-[#E94651]">
                     {formatNumber(row.price)}
                   </span>
                   <span className="text-xs text-[#E94651]">
-                    ({row.changePct >= 0 ? '+' : ''}
-                    {row.changePct.toFixed(1)}%)
+                    ({formatChange(row.changePct)})
                   </span>
                 </span>
-                <span className="pr-4 text-right font-semibold text-slate-300">
+                <span className="font-semibold text-slate-300">
                   —
                 </span>
               </div>
@@ -86,12 +87,12 @@ export function OrderBook() {
 
             <div className="my-1 h-px rounded-full bg-slate-200" />
 
-            {bidRows.map((row) => (
+            {ordersBuy.map((row) => (
               <div
                 key={`bid-${row.price}`}
-                className="grid grid-cols-3 items-center rounded-lg px-3 py-2 text-sm transition-colors hover:bg-[#F2F4F7]"
+                className="grid grid-cols-3 items-center rounded-lg px-3 py-4 text-sm transition-colors hover:bg-[#F2F4F7] text-center"
               >
-                <span className="pl-4 text-left font-semibold text-slate-300">
+                <span className="font-semibold text-slate-300">
                   —
                 </span>
                 <span className="flex items-center justify-center gap-2">
@@ -99,12 +100,11 @@ export function OrderBook() {
                     {formatNumber(row.price)}
                   </span>
                   <span className="text-xs text-[#2675EB]">
-                    ({row.changePct >= 0 ? '+' : ''}
-                    {row.changePct.toFixed(1)}%)
+                    ({formatChange(row.changePct)})
                   </span>
                 </span>
-                <span className="pr-4 text-right font-semibold text-[#E53333]">
-                  {formatNumber(row.bidQty!)}
+                <span className="font-semibold text-[#E53333]">
+                  {formatNumber(row.quantity)}
                 </span>
               </div>
             ))}
@@ -120,13 +120,13 @@ export function OrderBook() {
               <div className="flex items-center justify-between">
                 <dt>최고가</dt>
                 <dd className="font-semibold text-[#E53333]">
-                  {formatNumber(SUMMARY_STATS.weekHigh)}
+                  {summary ? formatNumber(summary.highestPrice) : '—'}
                 </dd>
               </div>
               <div className="flex items-center justify-between">
                 <dt>최저가</dt>
                 <dd className="font-semibold text-[#2563EB]">
-                  {formatNumber(SUMMARY_STATS.weekLow)}
+                  {summary ? formatNumber(summary.lowestPrice) : '—'}
                 </dd>
               </div>
             </dl>
@@ -137,19 +137,19 @@ export function OrderBook() {
               <div className="flex items-center justify-between">
                 <dt className="text-slate-500">상한가</dt>
                 <dd className="font-semibold text-[#E53333]">
-                  {formatNumber(SUMMARY_STATS.upper)}
+                  {summary ? formatNumber(summary.limitUpPrice) : '—'}
                 </dd>
               </div>
               <div className="flex items-center justify-between">
                 <dt className="text-slate-500">하한가</dt>
                 <dd className="font-semibold text-[#2563EB]">
-                  {formatNumber(SUMMARY_STATS.lower)}
+                  {summary ? formatNumber(summary.limitDownPrice) : '—'}
                 </dd>
               </div>
               <div className="flex items-center justify-between">
                 <dt className="text-slate-500">전일종가</dt>
                 <dd className="font-semibold text-slate-900">
-                  {formatNumber(SUMMARY_STATS.prevClose)}
+                  {summary ? formatNumber(summary.lastPrice) : '—'}
                 </dd>
               </div>
             </dl>

--- a/src/components/trade/info/image-info-panel.tsx
+++ b/src/components/trade/info/image-info-panel.tsx
@@ -25,17 +25,19 @@ export function ImageInfoPanel({ info }: ImageInfoPanelProps) {
             <ExternalLink className="h-4 w-4" />
           </Link>
         </div>
-        <div className="flex flex-1 w-full items-center justify-center rounded-xl bg-gray-200 text-sm text-gray-400">
-          {info.heroImage ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={info.heroImage}
-              alt={`${info.name} 대표작품`}
-              className="h-full w-full rounded-xl object-cover"
-            />
-          ) : (
-            <span>image</span>
-          )}
+        <div className="relative flex flex-1 w-full items-center justify-center rounded-xl bg-gray-200 text-sm text-gray-400 overflow-hidden">
+          <div className="relative w-full aspect-[16/9] overflow-hidden rounded-lg">
+            {info.heroImage ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={info.heroImage}
+                alt={`${info.name} 대표작품`}
+                className="absolute inset-0 h-full w-full object-cover"
+              />
+            ) : (
+              <span className="flex h-full w-full items-center justify-center">image</span>
+            )}
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/src/components/trade/info/revenue-chart.tsx
+++ b/src/components/trade/info/revenue-chart.tsx
@@ -2,15 +2,7 @@
 
 import type React from 'react';
 
-import {
-  useState,
-  useRef,
-  useMemo,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useId,
-} from 'react';
+import { useState, useRef, useMemo, useCallback, useEffect, useLayoutEffect, useId } from 'react';
 import type { RevenuePoint } from '@/lib/mock-info';
 
 interface RevenueChartProps {
@@ -26,17 +18,6 @@ export function RevenueChart({ data }: RevenueChartProps) {
     dateLabel: string;
   } | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const dragRef = useRef<{
-    active: boolean;
-    pointerId: number | null;
-    lastX: number;
-    accumulated: number;
-  }>({
-    active: false,
-    pointerId: null,
-    lastX: 0,
-    accumulated: 0,
-  });
   const [containerWidth, setContainerWidth] = useState(0);
   const [mounted, setMounted] = useState(false);
 
@@ -77,18 +58,6 @@ export function RevenueChart({ data }: RevenueChartProps) {
   const slicedData = data.slice(rangeStart, rangeEnd);
   const visibleData = slicedData.length > 0 ? slicedData : data;
 
-  const shiftWindow = useCallback(
-    (steps: number) => {
-      if (steps === 0 || data.length <= windowSize) return;
-      setRangeStart((prev) => {
-        const maxStart = Math.max(0, data.length - windowSize);
-        const next = Math.min(Math.max(prev - steps, 0), maxStart);
-        return next;
-      });
-    },
-    [data.length, windowSize],
-  );
-
   const width = containerWidth > 0 ? containerWidth : 1000;
   const height = 250;
   const padding = { top: 20, right: 28, bottom: 40, left: 24 };
@@ -98,16 +67,9 @@ export function RevenueChart({ data }: RevenueChartProps) {
   const gradientId = useId();
 
   const activeData = visibleData.length > 0 ? visibleData : data;
+  const hasData = activeData.length > 0;
 
-  if (activeData.length === 0) {
-    return (
-      <div className="flex h-[250px] w-full items-center justify-center rounded-lg bg-gradient-to-b from-blue-50/30 to-white text-xs text-gray-400">
-        ?쒖떆???곗씠?곌? ?놁뒿?덈떎.
-      </div>
-    );
-  }
-
-  const values = activeData.map((d) => d.value);
+  const values = hasData ? activeData.map((d) => d.value) : [0];
   const rawMin = Math.min(...values);
   const rawMax = Math.max(...values);
   const valueRange = Math.max(rawMax - rawMin, 1);
@@ -146,31 +108,32 @@ export function RevenueChart({ data }: RevenueChartProps) {
     [chartHeight, maxValue, minValue, padding.top],
   );
 
-  const { areaPath, linePath } = useMemo(() => {
+  const { areaPath, linePath, points } = useMemo(() => {
     if (!activeData.length) {
-      return { areaPath: '', linePath: '' };
+      return { areaPath: '', linePath: '', points: [] as { x: number; y: number }[] };
     }
-    const points = activeData.map((point, index) => ({
+    const pts = activeData.map((point, index) => ({
       x: xScale(index),
       y: yScaleValue(point.value),
     }));
-    const first = points[0];
-    const last = points[points.length - 1];
+    const first = pts[0];
+    const last = pts[pts.length - 1];
     const areaCommands = [
       'M ' + first.x + ' ' + chartBaseline,
       'L ' + first.x + ' ' + first.y,
-      ...points.slice(1).map((point) => 'L ' + point.x + ' ' + point.y),
+      ...pts.slice(1).map((point) => 'L ' + point.x + ' ' + point.y),
       'L ' + last.x + ' ' + chartBaseline,
       'L ' + first.x + ' ' + chartBaseline,
       'Z',
     ];
     const lineCommands = [
       'M ' + first.x + ' ' + first.y,
-      ...points.slice(1).map((point) => 'L ' + point.x + ' ' + point.y),
+      ...pts.slice(1).map((point) => 'L ' + point.x + ' ' + point.y),
     ];
     return {
       areaPath: areaCommands.join(' '),
       linePath: lineCommands.join(' '),
+      points: pts,
     };
   }, [activeData, chartBaseline, xScale, yScaleValue]);
 
@@ -195,134 +158,6 @@ export function RevenueChart({ data }: RevenueChartProps) {
     } as React.CSSProperties;
   }, [tooltip, width, padding.left, padding.right, padding.top]);
 
-  const updateHover = useCallback(
-    (clientX: number, clientY: number) => {
-      const rect = containerRef.current?.getBoundingClientRect();
-      if (!rect || chartWidth <= 0 || chartHeight <= 0) {
-        setTooltip(null);
-        return;
-      }
-
-      const localX = clientX - rect.left;
-      const localY = clientY - rect.top;
-      const relativeX = localX - padding.left;
-      const relativeY = localY - padding.top;
-
-      if (
-        relativeX < 0 ||
-        relativeX > chartWidth ||
-        relativeY < 0 ||
-        relativeY > chartHeight
-      ) {
-        setTooltip(null);
-        return;
-      }
-
-      const denominator = Math.max(activeData.length - 1, 1);
-      const index = Math.min(
-        activeData.length - 1,
-        Math.max(0, Math.round((relativeX / chartWidth) * denominator)),
-      );
-      const point = activeData[index];
-      if (!point) {
-        setTooltip(null);
-        return;
-      }
-
-      const xPos = xScale(index);
-      const yPos = yScaleValue(point.value);
-
-      const globalIndex = rangeStart + index;
-      const anchorDate = new Date();
-      anchorDate.setHours(0, 0, 0, 0);
-      anchorDate.setDate(1);
-      const offset = data.length - 1 - globalIndex;
-      const date = new Date(anchorDate);
-      date.setMonth(anchorDate.getMonth() - offset);
-      const monthNumber = date.getMonth() + 1;
-      const dateLabel =
-        date.getFullYear() +
-        '년 ' +
-        monthNumber +
-        '월 ' +
-        date.getDate() +
-        '일';
-
-      setTooltip({
-        x: xPos,
-        y: yPos,
-        value: point.value,
-        label: point.t,
-        dateLabel,
-      });
-    },
-    [activeData, chartWidth, data.length, padding.left, padding.top, rangeStart, xScale, yScaleValue],
-  );
-
-  const handlePointerDown = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      dragRef.current = {
-        active: true,
-        pointerId: e.pointerId,
-        lastX: e.clientX,
-        accumulated: 0,
-      };
-      e.currentTarget.setPointerCapture(e.pointerId);
-      updateHover(e.clientX, e.clientY);
-    },
-    [updateHover],
-  );
-
-  const handlePointerMove = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      const drag = dragRef.current;
-      if (drag.active) {
-        const movement = e.clientX - drag.lastX;
-        drag.lastX = e.clientX;
-        drag.accumulated += movement;
-
-        const threshold = 56;
-        const steps = Math.trunc(drag.accumulated / threshold);
-
-        if (steps !== 0) {
-          shiftWindow(steps);
-          drag.accumulated -= steps * threshold;
-        }
-      }
-
-      updateHover(e.clientX, e.clientY);
-    },
-    [shiftWindow, updateHover],
-  );
-
-  const endDrag = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (dragRef.current.active && dragRef.current.pointerId !== null) {
-      e.currentTarget.releasePointerCapture(dragRef.current.pointerId);
-    }
-    dragRef.current = {
-      active: false,
-      pointerId: null,
-      lastX: 0,
-      accumulated: 0,
-    };
-  }, []);
-
-  const handlePointerUp = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      endDrag(e);
-      updateHover(e.clientX, e.clientY);
-    },
-    [endDrag, updateHover],
-  );
-
-  const handlePointerLeave = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      endDrag(e);
-      setTooltip(null);
-    },
-    [endDrag],
-  );
-
   if (!mounted) {
     return (
       <div
@@ -338,11 +173,6 @@ export function RevenueChart({ data }: RevenueChartProps) {
     <div
       ref={containerRef}
       className="relative h-[250px] w-full rounded-lg bg-gradient-to-b from-blue-50/30 to-white"
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerUp={handlePointerUp}
-      onPointerLeave={handlePointerLeave}
-      onPointerCancel={handlePointerLeave}
     >
       <div className="absolute inset-0">
                 <svg width={width} height={height} role="img" aria-label="?? ?? ??">
@@ -383,7 +213,39 @@ export function RevenueChart({ data }: RevenueChartProps) {
               />
             </>
           )}
+
+          {points.map((point, idx) => (
+            <circle
+              key={'pt-' + idx}
+              cx={point.x}
+              cy={point.y}
+              r={5}
+              fill="#3b82f6"
+              stroke="#fff"
+              strokeWidth={1.5}
+              onMouseEnter={() => {
+                const dataPoint = activeData[idx];
+                const dateRaw = dataPoint?.date;
+                const formattedDate = dateRaw
+                  ? new Date(dateRaw).toLocaleDateString('ko-KR')
+                  : dataPoint?.t ?? '';
+                setTooltip({
+                  x: point.x,
+                  y: point.y,
+                  value: dataPoint?.value ?? 0,
+                  label: dataPoint?.t ?? '',
+                  dateLabel: formattedDate,
+                });
+              }}
+              onMouseLeave={() => setTooltip(null)}
+            />
+          ))}
         </svg>
+        {!hasData && (
+          <div className="absolute inset-0 flex items-center justify-center text-xs text-gray-400 bg-white/70 backdrop-blur-sm">
+            데이터가 없습니다.
+          </div>
+        )}
       </div>
 
       {tooltip && (
@@ -431,7 +293,7 @@ export function RevenueChart({ data }: RevenueChartProps) {
             >
               <div className="text-[11px] font-medium text-white/80">{tooltip.dateLabel}</div>
               <div className="mt-1 text-sm font-semibold">
-                {Math.round(tooltip.value).toLocaleString('ko-KR')}??
+                {Math.round(tooltip.value).toLocaleString('ko-KR')}원
               </div>
             </div>
           )}

--- a/src/components/trade/trade-card.tsx
+++ b/src/components/trade/trade-card.tsx
@@ -18,8 +18,21 @@ interface TradeCardProps {
 export function TradeCard({ item, onLikeToggle }: TradeCardProps) {
   const router = useRouter();
 
-  const isPositive = item.changePct >= 0;
-  const changeText = isPositive ? `+${item.changePct}%` : `${item.changePct}%`;
+  const changePct = Number(item.changePct);
+  const formattedChange = changePct.toFixed(1);
+  const isZero = changePct === 0;
+  const isPositive = changePct > 0;
+  const changeText = isZero
+    ? '0.0%'
+    : isPositive
+      ? `+${formattedChange}%`
+      : `${formattedChange}%`;
+
+  const badgeClass = isZero
+    ? 'bg-gray-100 text-gray-600'
+    : isPositive
+      ? 'bg-[#FFB8B8]/48 text-[#E53333]'
+      : 'bg-[#B8D9FF]/48 text-[#3386E5]';
 
   const handleCardNavigation = () => {
     router.push(`/trading/${item.id}`);
@@ -86,11 +99,7 @@ export function TradeCard({ item, onLikeToggle }: TradeCardProps) {
             </div>
 
             <span
-              className={`ml-2 inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium whitespace-nowrap ${
-                isPositive
-                  ? 'bg-[#FFB8B8]/48 text-[#E53333]'
-                  : 'bg-[#B8D9FF]/48 text-[#3386E5]'
-              }`}
+              className={`ml-2 inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium whitespace-nowrap ${badgeClass}`}
             >
               {changeText}
             </span>

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils"
 type PopoverContextValue = {
   open: boolean
   setOpen: (open: boolean) => void
-  triggerRef: React.RefObject<HTMLElement>
+  triggerRef: React.RefObject<HTMLElement | null>
 }
 
 const PopoverContext = React.createContext<PopoverContextValue | null>(null)
@@ -100,14 +100,15 @@ const PopoverTrigger = React.forwardRef<HTMLButtonElement, PopoverTriggerProps>(
     }
 
     if (asChild && React.isValidElement(children)) {
+      const childWithProps = children as React.ReactElement<any> & { ref?: React.Ref<any> }
       const composedOnClick = composeEventHandlers(
-        composeEventHandlers(children.props.onClick, onClick),
+        composeEventHandlers(childWithProps.props.onClick, onClick),
         () => setOpen(!open),
       )
-      return React.cloneElement(children, {
-        ref: mergeRefs(children.ref, (node: HTMLElement | null) => {
-          triggerRef.current = node || undefined
-        }) as React.Ref<any>,
+      return React.cloneElement(childWithProps, {
+        ref: mergeRefs(childWithProps.ref ?? null, (node: HTMLElement | null) => {
+          triggerRef.current = node
+        }),
         "aria-haspopup": "dialog",
         "aria-expanded": open,
         onClick: composedOnClick,
@@ -119,7 +120,7 @@ const PopoverTrigger = React.forwardRef<HTMLButtonElement, PopoverTriggerProps>(
       <button
         type="button"
         ref={(node) => {
-          triggerRef.current = node || undefined
+          triggerRef.current = node
           if (typeof ref === "function") {
             ref(node)
           } else if (ref) {

--- a/src/lib/mock-info.ts
+++ b/src/lib/mock-info.ts
@@ -1,4 +1,4 @@
-export type RevenuePoint = { t: string; value: number };
+export type RevenuePoint = { t: string; value: number; date?: string };
 
 export type SecurityInfo = {
   id: string;


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 2차 거래 상품 리스트 조회
- 2차 거래 상품 상세 정보 조회
- 구매하기
- 판매하기
- 대기 목록 불러오기
- 특정 상품 특정 유저 거래 내역 조회
- 호가


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 구매, 판매, 대기 목록 조회 API는 서버 수정 후 테스트 재진행하겠습니다.
- close: #19 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
| 제목 | 화면 캡처 |
| ---- | -------- |
| 거래 리스트 `/trading` |  <img width="800" alt="image" src="https://github.com/user-attachments/assets/508742f3-f76d-406f-af10-32ff9d204d3b" />|
| 거래 상세 - 호가 `/trading/{id}` | <img width="800" alt="image" src="https://github.com/user-attachments/assets/42331206-4875-4533-b7c2-0433571e3d50" />|
| 거래 상세 - 종목소개/공시 `/trading/{id}` | <img width="800" alt="image" src="https://github.com/user-attachments/assets/21d3db19-24d2-444f-92c9-d82c8a8b3c7b" /> |