### PR TITLE
[#26] feat: 메인API 연결

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,27 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "hebbkx1anhila5yf.public.blob.vercel-storage.com",
       },
+      {
+        protocol: "http",
+        hostname: "localhost",
+        port: "8080",
+      },
+      {
+        protocol: "https",
+        hostname: "i.namu.wiki",
+      },
+      {
+        protocol: "https",
+        hostname: "img.danawa.com",
+      },
+      {
+        protocol: "https",
+        hostname: "cdn.huffingtonpost.kr",
+      },
+      {
+        protocol: "https",
+        hostname: "i.pinimg.com",
+      },
     ],
   },
 };

--- a/src/app/(pages)/main/components/HeroBanner.tsx
+++ b/src/app/(pages)/main/components/HeroBanner.tsx
@@ -22,7 +22,7 @@ export function HeroBanner({ banners }: HeroBannerProps) {
   const currentBanner = banners[currentSlide] ?? { alt: "", imageUrl: "" }
 
   return (
-    <div className="relative w-full h-[360px] bg-gray-200 overflow-hidden">
+    <div className="relative w-full h-[552px] bg-gray-200 overflow-hidden">
       {currentBanner.imageUrl ? (
         <Image
           src={currentBanner.imageUrl || "/placeholder.svg"}
@@ -30,6 +30,7 @@ export function HeroBanner({ banners }: HeroBannerProps) {
           fill
           className="object-cover"
           priority
+          unoptimized
         />
       ) : (
         <div className="absolute inset-0" />

--- a/src/app/(pages)/main/components/MarketCard.tsx
+++ b/src/app/(pages)/main/components/MarketCard.tsx
@@ -1,55 +1,222 @@
-﻿"use client"
+"use client"
 
-import { useState } from "react"
+import { useEffect, useRef, useState, type KeyboardEvent, type MouseEvent } from "react"
 import Image from "next/image"
-import Link from "next/link"
 import type { Item } from "../constants/data"
 import { StatusPill } from "./StatusPill"
 import iconCoin from "../assets/icon_coin.png"
 import iconHeartDefault from "../assets/icon_heart.svg"
 import iconHeartActive from "../assets/icon_heart_active.svg"
+import { apiFetch } from "@/lib/api-client"
+import { getAccessToken } from "@/lib/auth"
+import { useRouter } from "next/navigation"
 
 interface MarketCardProps {
   item: Item
 }
 
+const allowedRemoteHosts = new Set([
+  "hebbkx1anhila5yf.public.blob.vercel-storage.com",
+  "i.namu.wiki",
+  "img.danawa.com",
+  "cdn.huffingtonpost.kr",
+  "i.pinimg.com",
+])
+
+const apiHost = (() => {
+  const base = process.env.NEXT_PUBLIC_API_URL
+  if (!base) return null
+  try {
+    return new URL(base).hostname
+  } catch {
+    return null
+  }
+})()
+
+if (apiHost) {
+  allowedRemoteHosts.add(apiHost)
+}
+
+function normalizeImageUrl(url?: string) {
+  if (!url) return undefined
+  if (url.startsWith("http://") || url.startsWith("https://")) {
+    try {
+      const parsed = new URL(url)
+      if (parsed.hostname === "www.google.com" && parsed.pathname === "/url") {
+        return undefined
+      }
+      if (!allowedRemoteHosts.has(parsed.hostname)) {
+        return undefined
+      }
+      return url
+    } catch {
+      return undefined
+    }
+  }
+  const base = process.env.NEXT_PUBLIC_API_URL
+  if (!base) {
+    return url.startsWith("/") ? url : `/${url}`
+  }
+  const normalizedPath = url.startsWith("/") ? url : `/${url}`
+  try {
+    const absolute = new URL(normalizedPath, base).toString()
+    const host = new URL(absolute).hostname
+    if (!allowedRemoteHosts.has(host)) {
+      return undefined
+    }
+    return absolute
+  } catch {
+    return undefined
+  }
+}
+
 export function MarketCard({ item }: MarketCardProps) {
   const [liked, setLiked] = useState(item.liked || false)
+  const [isToggling, setIsToggling] = useState(false)
+  const [isLoadingDetail, setIsLoadingDetail] = useState(false)
+  const [toastMessage, setToastMessage] = useState<string | null>(null)
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const imageUrl = normalizeImageUrl(item.imageUrl)
+  const router = useRouter()
+
+  useEffect(() => {
+    return () => {
+      if (toastTimer.current) {
+        clearTimeout(toastTimer.current)
+      }
+    }
+  }, [])
+
+  const showToast = (message: string) => {
+    setToastMessage(message)
+    if (toastTimer.current) clearTimeout(toastTimer.current)
+    toastTimer.current = setTimeout(() => setToastMessage(null), 2200)
+  }
+
+  const detailEndpoint =
+    item.status === "OFFERING"
+      ? `/v1/offerings/${item.id}/detail`
+      : item.status === "TRADING"
+        ? `/v1/market/${item.id}/details`
+        : null
+
+  const detailRoute = item.status === "OFFERING" ? `/offering/${item.id}` : `/trading/${item.id}`
+
+  const handleFavoriteToggle = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (isToggling) return
+
+    const token = getAccessToken()
+    if (!token) {
+      showToast("로그인이 필요한 서비스입니다.")
+      return
+    }
+
+    setIsToggling(true)
+    try {
+      const method = liked ? "DELETE" : "POST"
+      const res = await apiFetch(`/v1/products/${item.id}/favorite`, { method })
+      if (!res.ok) {
+        let message: string | undefined
+        try {
+          const error = (await res.json()) as { detail?: string; message?: string }
+          message = error.detail || error.message
+        } catch {
+          /* ignore */
+        }
+        throw new Error(message || "관심 등록 처리에 실패했습니다.")
+      }
+      setLiked((prev) => !prev)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "관심 등록 처리에 실패했습니다."
+      showToast(message)
+    } finally {
+      setIsToggling(false)
+    }
+  }
+
+  const fetchDetailAndNavigate = async () => {
+    if (!detailEndpoint || !detailRoute || isLoadingDetail) return
+
+    setIsLoadingDetail(true)
+    try {
+      const res = await apiFetch(detailEndpoint)
+      if (!res.ok) {
+        let message: string | undefined
+        try {
+          const error = (await res.json()) as { detail?: string; message?: string }
+          message = error.detail || error.message
+        } catch {
+          /* ignore */
+        }
+        throw new Error(message || "상세 정보를 불러오지 못했습니다.")
+      }
+      const detail = await res.json().catch(() => null)
+      if (detail) {
+        sessionStorage.setItem(`product-detail:${item.status}:${item.id}`, JSON.stringify(detail))
+      }
+      router.push(detailRoute)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "상세 정보를 불러오지 못했습니다."
+      showToast(message)
+    } finally {
+      setIsLoadingDetail(false)
+    }
+  }
+
+  const handleCardKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault()
+      fetchDetailAndNavigate()
+    }
+  }
 
   return (
     <div className="group">
-      <Link href={`/product/${item.id}`} className="block">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={fetchDetailAndNavigate}
+        onKeyDown={handleCardKeyDown}
+        className="block cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#3386E5]"
+      >
         <div className="relative aspect-[4/3] lg:aspect-[5/4] bg-gray-100 rounded-lg mb-3 overflow-hidden">
-          {item.imageUrl ? (
-            <Image src={item.imageUrl || "/placeholder.svg"} alt={item.title} fill className="object-cover" />
+          {imageUrl ? (
+            <Image src={imageUrl} alt={item.title} fill className="object-cover" unoptimized />
           ) : (
             <div className="absolute inset-0 flex items-center justify-center text-gray-900 text-lg">image</div>
           )}
+          {isLoadingDetail ? (
+            <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/40 text-white text-xs">
+              <span>상세 정보를 불러오는 중...</span>
+            </div>
+          ) : null}
           <button
-            onClick={(e) => {
-              e.preventDefault()
-              setLiked((prev) => !prev)
-            }}
+            onClick={handleFavoriteToggle}
             type="button"
-            className="absolute top-2 right-2 z-10 p-0 bg-transparent border-0 appearance-none cursor-pointer"
+            className="absolute top-2 right-2 z-10 p-0 bg-transparent border-0 appearance-none cursor-pointer disabled:cursor-not-allowed"
             aria-label={liked ? '\uCC2C \uCDE8\uC18C' : '\uCC2C\uD558\uAE30'}
+            aria-pressed={liked}
+            disabled={isToggling}
           >
             <Image src={liked ? iconHeartActive : iconHeartDefault} alt="" width={24} height={24} />
           </button>
         </div>
-      </Link>
-      <div className="flex items-start justify-between mb-1">
-        <Link href={`/product/${item.id}`}>
+        <div className="flex items-start justify-between mb-1">
           <h3 className="font-semibold text-base text-gray-900 hover:text-[#3386E5] transition-colors">{item.title}</h3>
-        </Link>
-        <StatusPill status={item.status} />
+          <StatusPill status={item.status} />
+        </div>
+        <div className="flex items-center gap-1">
+          <Image src={iconCoin} alt="" width={16} height={16} />
+          <span className="text-sm font-semibold text-gray-900">{item.priceKRW}{'\uC6D0'}</span>
+        </div>
       </div>
-      <div className="flex items-center gap-1">
-        <Image src={iconCoin} alt="" width={16} height={16} />
-        <span className="text-sm font-semibold text-gray-900">{item.priceKRW}{'\uC6D0'}</span>
-      </div>
+      {toastMessage ? (
+        <div className="fixed bottom-6 right-6 z-50 rounded-md bg-black/80 px-4 py-2 text-sm text-white shadow-lg">
+          {toastMessage}
+        </div>
+      ) : null}
     </div>
   )
 }
-
-

--- a/src/app/(pages)/main/page.tsx
+++ b/src/app/(pages)/main/page.tsx
@@ -1,18 +1,85 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import Image from "next/image"
 import Link from "next/link"
 import { HeroBanner } from "./components/HeroBanner"
 import { MarketCard } from "./components/MarketCard"
-import type { Item, Banner } from "./constants/data"
+import type { Item, Banner, ItemStatus } from "./constants/data"
 import { SAMPLE_BANNERS, SAMPLE_OFFERING, SAMPLE_TRADING } from "./constants/data"
 import iconMore from "./assets/icon_more.png"
+import { getAccessToken } from "@/lib/auth"
+
+const apiBase = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
+
+type HomeResponse = {
+  banners?: Array<{
+    bannerId: number
+    imageUrl?: string
+    title?: string
+    description?: string
+  }>
+  offeringProducts?: ApiProduct[]
+  tradingProducts?: ApiProduct[]
+}
+
+type ApiProduct = {
+  productId: number
+  productName: string
+  currentPrice: number
+  thumbnailImg?: string
+  favorite?: boolean
+}
 
 export default function Home() {
-  const offering: Item[] = SAMPLE_OFFERING
-  const trading: Item[] = SAMPLE_TRADING
-  const banners: Banner[] = SAMPLE_BANNERS
+  const [banners, setBanners] = useState<Banner[]>(SAMPLE_BANNERS)
+  const [offering, setOffering] = useState<Item[]>(SAMPLE_OFFERING)
+  const [trading, setTrading] = useState<Item[]>(SAMPLE_TRADING)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    let mounted = true
+
+    const loadData = async () => {
+      try {
+        const token = getAccessToken()
+        const res = await fetch(`${apiBase}/v1/main/home`, {
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        })
+        if (!res.ok) {
+          throw new Error(`Failed to fetch home data: ${res.status}`)
+        }
+        const data = (await res.json()) as HomeResponse
+        if (!mounted) return
+
+        const nextBanners = mapBanners(data.banners)
+        const nextOffering = mapProducts(data.offeringProducts, "OFFERING")
+        const nextTrading = mapProducts(data.tradingProducts, "TRADING")
+
+        setBanners(nextBanners.length ? nextBanners : SAMPLE_BANNERS)
+        setOffering(nextOffering.length ? nextOffering : SAMPLE_OFFERING)
+        setTrading(nextTrading.length ? nextTrading : SAMPLE_TRADING)
+        setErrorMessage(null)
+      } catch (error) {
+        console.error("Failed to load home data", error)
+        if (!mounted) return
+        setBanners(SAMPLE_BANNERS)
+        setOffering(SAMPLE_OFFERING)
+        setTrading(SAMPLE_TRADING)
+        setErrorMessage("메인 데이터를 불러오지 못해 임시 배너를 표시하고 있어요. API 서버 상태를 확인해주세요.")
+      }
+    }
+
+    loadData()
+
+    return () => {
+      mounted = false
+    }
+  }, [])
 
   return (
     <main className="text-[14px]">
+      {errorMessage ? <div className="bg-[#FFF6E6] text-[#8A5800] px-6 py-3 text-center text-[13px]">{errorMessage}</div> : null}
       <HeroBanner banners={banners} />
       <div className="container mx-auto px-8 sm:px-12 lg:px-16 xl:px-20 py-12">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 lg:gap-12">
@@ -46,4 +113,32 @@ export default function Home() {
       </div>
     </main>
   )
+}
+
+function resolveAssetUrl(path?: string) {
+  if (!path) return undefined
+  if (path.startsWith("http://") || path.startsWith("https://")) return path
+  const normalized = path.startsWith("/") ? path : `/${path}`
+  return `${apiBase}${normalized}`
+}
+
+function mapBanners(banners?: HomeResponse["banners"]): Banner[] {
+  if (!banners) return []
+  return banners.map((banner, index) => ({
+    id: banner.bannerId?.toString() ?? `banner-${index}`,
+    alt: banner.title || banner.description || "메인 배너",
+    imageUrl: resolveAssetUrl(banner.imageUrl),
+  }))
+}
+
+function mapProducts(products: ApiProduct[] | undefined, status: ItemStatus): Item[] {
+  if (!products) return []
+  return products.map((product) => ({
+    id: product.productId.toString(),
+    title: product.productName,
+    priceKRW: product.currentPrice,
+    status,
+    liked: Boolean(product.favorite),
+    imageUrl: resolveAssetUrl(product.thumbnailImg),
+  }))
 }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
메인 홈을 백엔드 연동 기준으로 리팩터링해 배너/상품 데이터를 API에서 읽어오고, 상품 카드에서 즐겨찾기·상세 진입 로직까지 모두 실제 엔드포인트와 연결했습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- `/v1/main/home` 호출 시 로그인 중이면 JWT를 헤더에 붙여 전송하고, 응답의 favorite 값을 그대로 카드 상태에 반영하도록 타입을 수정했습니다.
- MarketCard 하트 버튼이 POST/DELETE `/v1/products/{productId}/favorite`를 호출하게 했고, 로그인 없음/오류 상황은 브라우저 alert 대신 토스트로 안내합니다.
- 카드 클릭 시 OFFERING은 `/v1/offerings/{id}/detail`, TRADING은 `/v1/market/{id}/details`를 미리 호출해 세션 스토리지에 캐시한 뒤 `/offering/{id}`, `/trading/{id}`로 라우팅합니다.
- 상대경로 썸네일·배너는 백엔드 베이스 URL 기준으로 정규화했고, Next 이미지 최적화가 막히는 외부 호스트들은 remotePatterns/화이트리스트에 추가했습니다.
- close: #26 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

|   제목   | 화면 캡처 |
| ------- | -------- |
| 메인페이지 로딩 | ![main1120](https://github.com/user-attachments/assets/e9b1258c-4ae0-4cee-8dac-c70b0a032e84) |
| 좋아요리스트 조회 | <img width="1913" height="453" alt="image" src="https://github.com/user-attachments/assets/29104658-ef55-4a4b-a364-ceb178b2742b" /> <img width="991" height="182" alt="image" src="https://github.com/user-attachments/assets/a1b8ae20-3ad0-40ab-80d6-76d8c9932bc1" /> |
| 좋아요리스트 반영 | ![favorite1120](https://github.com/user-attachments/assets/77c27b88-1ea6-43c8-872d-1235c9197f1c) |
| 미로그인시 좋아요 | <img width="944" height="566" alt="image" src="https://github.com/user-attachments/assets/34082774-08c3-477c-892a-89b5092b4bfa" /> |


