### PR TITLE
[#25] feat: 2차거래 시세 차트 조회 API 연결

### DIFF
--- a/src/app/(pages)/components/PageShell.tsx
+++ b/src/app/(pages)/components/PageShell.tsx
@@ -1,12 +1,73 @@
 "use client"
 
 import type { ReactNode } from "react"
+import { useEffect, useState } from "react"
 import { usePathname } from "next/navigation"
 
 import { Header } from "../main/layouts/Header"
 import { Footer } from "../main/layouts/Footer"
 
 const AUTH_PATH_PREFIX = "/auth"
+
+type LayoutSpacing = {
+  header: string
+  footer: string
+  footerBackground?: string
+}
+
+const DEFAULT_SPACING: LayoutSpacing = {
+  header: "container mx-auto px-10 sm:px-16 lg:px-20 xl:px-24",
+  footer: "container mx-auto px-8 sm:px-12 lg:px-16 xl:px-20",
+}
+
+const LAYOUT_VARIANTS: Array<{
+  test: (path: string) => boolean
+  spacing: LayoutSpacing
+}> = [
+  {
+    test: (path) => /^\/trading\/[^/]+$/.test(path),
+    spacing: {
+      header: "mx-auto w-full max-w-[1680px] px-6 lg:px-12",
+      footer: "mx-auto w-full max-w-[1680px] px-6 lg:px-12",
+      footerBackground: "bg-white",
+    },
+  },
+  {
+    test: (path) => path === "/trading",
+    spacing: {
+      header: "mx-auto w-full max-w-[1280px] px-6",
+      footer: "mx-auto w-full max-w-[1280px] px-6",
+    },
+  },
+  {
+    test: (path) => path === "/" || path.startsWith("/main"),
+    spacing: {
+      header: "container mx-auto px-8 sm:px-12 lg:px-16 xl:px-20",
+      footer: "container mx-auto px-8 sm:px-12 lg:px-16 xl:px-20",
+    },
+  },
+  {
+    test: (path) => path.startsWith("/offering"),
+    spacing: {
+      header: "mx-auto w-full max-w-[1280px] px-6",
+      footer: "mx-auto w-full max-w-[1280px] px-6",
+    },
+  },
+  {
+    test: (path) => path.startsWith("/mypage"),
+    spacing: {
+      header: "mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8",
+      footer: "mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8",
+    },
+  },
+]
+
+function resolveSpacing(pathname?: string | null): LayoutSpacing {
+  if (!pathname) return DEFAULT_SPACING
+  const normalized = pathname.endsWith("/") && pathname.length > 1 ? pathname.slice(0, -1) : pathname
+  const match = LAYOUT_VARIANTS.find((variant) => variant.test(normalized))
+  return match?.spacing ?? DEFAULT_SPACING
+}
 
 type PageShellProps = {
   children: ReactNode
@@ -15,6 +76,11 @@ type PageShellProps = {
 export function PageShell({ children }: PageShellProps) {
   const pathname = usePathname()
   const isAuthRoute = pathname?.startsWith(AUTH_PATH_PREFIX)
+  const [spacing, setSpacing] = useState<LayoutSpacing>(DEFAULT_SPACING)
+
+  useEffect(() => {
+    setSpacing(resolveSpacing(pathname))
+  }, [pathname])
 
   if (isAuthRoute) {
     return <>{children}</>
@@ -22,9 +88,9 @@ export function PageShell({ children }: PageShellProps) {
 
   return (
     <div className="min-h-screen flex flex-col bg-white">
-      <Header />
+      <Header containerClassName={spacing.header} />
       <div className="flex-1 flex flex-col">{children}</div>
-      <Footer />
+      <Footer containerClassName={spacing.footer} backgroundClassName={spacing.footerBackground} />
     </div>
   )
 }

--- a/src/app/(pages)/main/layouts/Footer.tsx
+++ b/src/app/(pages)/main/layouts/Footer.tsx
@@ -1,10 +1,20 @@
 import Image from "next/image"
 import Logo from "../assets/Logo.png"
 
-export function Footer() {
+type FooterProps = {
+  containerClassName?: string
+  backgroundClassName?: string
+}
+
+export function Footer({ containerClassName, backgroundClassName }: FooterProps) {
+  const defaultSpacing = 'container mx-auto px-8 sm:px-12 lg:px-16 xl:px-20'
+  const resolvedContainer = containerClassName ?? defaultSpacing
+  const background = backgroundClassName ?? 'bg-[#E6F0FC]'
+  const footerClass = `${background} py-8 mt-12`
+
   return (
-    <footer className="bg-[#E6F0FC] py-8 mt-12">
-      <div className="container mx-auto px-8 sm:px-12 lg:px-16 xl:px-20">
+    <footer className={footerClass}>
+      <div className={resolvedContainer}>
         <div className="mb-4">
           <Image src={Logo} alt="iPiece" width={100} height={27} className="h-7 w-auto" />
         </div>

--- a/src/app/(pages)/main/layouts/Header.tsx
+++ b/src/app/(pages)/main/layouts/Header.tsx
@@ -7,7 +7,11 @@ import Logo from "../assets/Logo.png"
 import { Button } from "../components/ui/button"
 import { ACCESS_TOKEN_KEY } from "@/lib/auth"
 
-export function Header() {
+type HeaderProps = {
+  containerClassName?: string
+}
+
+export function Header({ containerClassName }: HeaderProps) {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
   const avatarSrc = 'https://i.pravatar.cc/28'
   const pathname = usePathname()
@@ -25,10 +29,12 @@ export function Header() {
     const hasAccessToken = !!localStorage.getItem(ACCESS_TOKEN_KEY)
     setIsLoggedIn(hasAccessToken)
   }, [])
+  const defaultSpacing = 'container mx-auto px-10 sm:px-16 lg:px-20 xl:px-24'
+  const resolvedContainer = `${containerClassName ?? defaultSpacing} h-16 flex items-center justify-between`
 
   return (
-    <header className="border-b bg-white sticky top-0 z-50">
-      <div className="container mx-auto px-10 sm:px-16 lg:px-20 xl:px-24 h-16 flex items-center justify-between">
+    <header className="border-b bg-white">
+      <div className={resolvedContainer}>
         <div className="flex items-center gap-8">
           <Link href="/" className="cursor-pointer">
             <Image src={Logo} alt="iPiece" width={120} height={32} className="h-8 w-auto" />

--- a/src/app/(pages)/trading/[id]/page.tsx
+++ b/src/app/(pages)/trading/[id]/page.tsx
@@ -409,7 +409,7 @@ export default function TradingDetailPage() {
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-[620px_320px_minmax(0,1fr)] lg:[--panel-height:640px] items-stretch">
             {/* Chart - Left Column */}
             <div className="lg:h-[var(--panel-height)] lg:w-[620px]">
-              <TradingChart />
+              <TradingChart productId={productInfo?.product_id ?? Number(id)} />
             </div>
 
             {/* Order Form - Middle Column */}

--- a/src/app/(pages)/trading/[id]/page.tsx
+++ b/src/app/(pages)/trading/[id]/page.tsx
@@ -311,8 +311,8 @@ export default function TradingDetailPage() {
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
-      <header className="bg-white border-b sticky top-0 z-10">
-        <div className="mx-auto w-full max-w-[1560px] px-4 sm:px-8 lg:px-16 py-4">
+      <header className="bg-white border-b">
+        <div className="mx-auto w-full max-w-[1680px] px-6 lg:px-12 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
               <div className="w-12 h-12 rounded-lg overflow-hidden bg-gray-100">

--- a/src/app/(pages)/trading/page.tsx
+++ b/src/app/(pages)/trading/page.tsx
@@ -125,34 +125,36 @@ export default function HomePage() {
   const totalItems = totalCount ?? items.length;
 
   return (
-    <main className="flex-1 p-6 md:p-8">
-      {/* <NavTabs /> */}
-      <div className="mb-6">
-        <span className="inline-flex items-center justify-center bg-gray-100 text-gray-900 font-medium px-3 py-1 rounded text-sm">
-          {totalItems}개
-        </span>
-      </div>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-        {items.map((item) => (
-          <TradeCard
-            key={item.id}
-            item={item}
-            onLikeToggle={handleLikeToggle}
-          />
-        ))}
-      </div>
-
-      {hasMore && (
-        <div ref={sentinelRef} className="flex justify-center py-8">
-          {isLoading && (
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-              <span>로딩 중...</span>
-            </div>
-          )}
+    <main className="flex-1 bg-white">
+      <div className="mx-auto w-full max-w-[1280px] px-6 py-6">
+        {/* <NavTabs /> */}
+        <div className="mb-6">
+          <span className="inline-flex items-center justify-center bg-gray-100 text-gray-900 font-medium px-3 py-1 rounded text-sm">
+            {totalItems}개
+          </span>
         </div>
-      )}
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+          {items.map((item) => (
+            <TradeCard
+              key={item.id}
+              item={item}
+              onLikeToggle={handleLikeToggle}
+            />
+          ))}
+        </div>
+
+        {hasMore && (
+          <div ref={sentinelRef} className="flex justify-center py-8">
+            {isLoading && (
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                <span>로딩 중...</span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
     </main>
   );
 }

--- a/src/components/trade/chart/chart.tsx
+++ b/src/components/trade/chart/chart.tsx
@@ -13,14 +13,21 @@ import {
   useId,
 } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
-import {
-  MOCK_CANDLES_1D,
-  MOCK_CANDLES_1M,
-  MOCK_CANDLES_1W,
-  type Candle,
-} from '@/lib/mock-trading';
+import type { Candle } from '@/lib/mock-trading';
+import { apiFetch } from '@/lib/api-client';
 
 type Period = '1D' | '1W' | '1M';
+type ChartInterval = '1d' | '1w' | '1m';
+
+type ChartApiResponse = {
+  product_id: number;
+  interval: ChartInterval;
+  window?: { start_at: string; end_at: string };
+  points?: Array<{ ts: string; price: number; volume?: number }>;
+  has_more?: boolean;
+  next_cursor?: string;
+  fetched_at?: string;
+};
 
 interface HoverPoint {
   candle: Candle;
@@ -28,8 +35,15 @@ interface HoverPoint {
   y: number;
 }
 
-export function TradingChart() {
-  const [period, setPeriod] = useState<Period>('1D');
+interface TradingChartProps {
+  productId?: number | string;
+}
+
+export function TradingChart({ productId }: TradingChartProps) {
+  const [period, setPeriod] = useState<Period>('1W');
+  const [candles, setCandles] = useState<Candle[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [hoveredPoint, setHoveredPoint] = useState<HoverPoint | null>(null);
   const chartAreaRef = useRef<HTMLDivElement>(null);
   const chartScrollRef = useRef<HTMLDivElement>(null);
@@ -45,14 +59,7 @@ export function TradingChart() {
     accumulated: 0,
   });
 
-  const data =
-    period === '1D'
-      ? MOCK_CANDLES_1D
-      : period === '1W'
-        ? MOCK_CANDLES_1W
-        : MOCK_CANDLES_1M;
-
-  const visibleData = data;
+  const visibleData = candles;
 
   const height = 320;
   const padding = { top: 68, right: 28, bottom: 88, left: 40 };
@@ -71,9 +78,7 @@ export function TradingChart() {
   );
   const chartHeight = height - padding.top - padding.bottom;
   const chartBaseline = padding.top + chartHeight;
-  const [mounted, setMounted] = useState(false);
   const gradientId = useId();
-  useEffect(() => setMounted(true), []);
 
   useLayoutEffect(() => {
     const element = chartScrollRef.current;
@@ -94,11 +99,12 @@ export function TradingChart() {
     const scroller = chartScrollRef.current;
     if (!scroller) return;
     scroller.scrollLeft = scroller.scrollWidth - scroller.clientWidth;
-  }, [period, data.length, baseCanvasWidth]);
+  }, [period, visibleData.length, baseCanvasWidth]);
 
-  const prices = visibleData.map((d) => d.c);
-  const minPrice = Math.min(...prices) * 0.98;
-  const maxPrice = Math.max(...prices) * 1.02;
+  const hasData = visibleData.length > 0;
+  const prices = hasData ? visibleData.map((d) => d.c) : [0];
+  const minPrice = hasData ? Math.min(...prices) * 0.98 : 0;
+  const maxPrice = hasData ? Math.max(...prices) * 1.02 : 0;
 
   const xScale = (index: number) => {
     if (visibleData.length <= 1) {
@@ -138,10 +144,10 @@ export function TradingChart() {
     };
   }, [chartBaseline, visibleData, xScale, yScale]);
 
-  const yTicks = useMemo(
-    () => [minPrice, (minPrice + maxPrice) / 2, maxPrice],
-    [maxPrice, minPrice],
-  );
+  const yTicks = useMemo(() => {
+    if (!hasData) return [0];
+    return [minPrice, (minPrice + maxPrice) / 2, maxPrice];
+  }, [hasData, minPrice, maxPrice]);
 
   const axisLabels = useMemo(() => {
     if (visibleData.length === 0) return [];
@@ -153,6 +159,68 @@ export function TradingChart() {
       return visibleData[idx]?.t ?? '';
     });
   }, [visibleData]);
+
+  const mapPointLabel = useCallback(
+    (timestamp: string) => {
+      const date = new Date(timestamp);
+      if (Number.isNaN(date.getTime())) return timestamp;
+      if (period === '1D') {
+        return `${date.getHours().toString().padStart(2, '0')}:${date
+          .getMinutes()
+          .toString()
+          .padStart(2, '0')}`;
+      }
+      return `${date.getMonth() + 1}/${date.getDate()}`;
+    },
+    [period],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchChart = async () => {
+      if (!productId) {
+        setCandles([]);
+        return;
+      }
+      setIsLoading(true);
+      setErrorMessage(null);
+      try {
+        const intervalParam = period.toLowerCase() as ChartInterval;
+        const res = await apiFetch(
+          `/v1/market/${productId}/chart?interval=${intervalParam}`,
+        );
+        if (!res.ok) {
+          throw new Error(`Failed chart fetch: ${res.status}`);
+        }
+        const payload = (await res.json()) as ChartApiResponse;
+        const mapped = (payload.points ?? []).map((point) => ({
+          t: mapPointLabel(point.ts),
+          o: point.price,
+          h: point.price,
+          l: point.price,
+          c: point.price,
+          v: point.volume ?? 0,
+        }));
+        if (!cancelled) {
+          setCandles(mapped);
+        }
+      } catch (err) {
+        console.error('Failed to fetch chart data', err);
+        if (!cancelled) {
+          setErrorMessage('차트를 불러오지 못했습니다.');
+          setCandles([]);
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    fetchChart();
+    return () => {
+      cancelled = true;
+    };
+  }, [mapPointLabel, period, productId]);
 
   const tooltipStyle = useMemo(() => {
     if (!hoveredPoint) return null;
@@ -331,12 +399,12 @@ export function TradingChart() {
           </div>
         </div>
 
-        {mounted ? (
-          <div
-            ref={chartScrollRef}
-            className="relative -mx-4 flex-1 select-none overflow-x-auto overflow-y-hidden px-2 py-2 pb-6"
-            style={scrollStyle}
-          >
+        <div
+          ref={chartScrollRef}
+          className="relative -mx-4 flex-1 select-none overflow-x-auto overflow-y-hidden px-2 py-2 pb-6"
+          style={scrollStyle}
+        >
+          {hasData ? (
             <div
               ref={chartAreaRef}
               className="relative h-full"
@@ -403,8 +471,19 @@ export function TradingChart() {
                       strokeLinejoin="round"
                       strokeLinecap="round"
                     />
-                  </>
-                )}
+                    {visibleData.map((candle, index) => (
+                      <circle
+                        key={`point-${candle.t}-${index}`}
+                        cx={xScale(index)}
+                        cy={yScale(candle.c)}
+                        r={4}
+                        fill="#1A4DE5"
+                        stroke="#ffffff"
+                        strokeWidth={1}
+                      />
+                    ))}
+                 </>
+               )}
               </svg>
 
               {hoveredPoint && (
@@ -471,18 +550,16 @@ export function TradingChart() {
                 ))}
               </div>
             </div>
-          </div>
-        ) : (
-          <div
-            ref={chartScrollRef}
-            className="relative -mx-4 flex-1 select-none px-2 py-2 pb-6"
-            style={scrollStyle}
-          >
+          ) : (
             <div className="flex h-[320px] items-center justify-center rounded-xl border border-dashed border-slate-200 text-sm text-slate-400">
-              차트 준비 중...
+              {errorMessage
+                ? errorMessage
+                : isLoading
+                  ? '차트 데이터를 불러오는 중...'
+                  : '차트 준비 중...'}
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/components/trade/chart/chart.tsx
+++ b/src/components/trade/chart/chart.tsx
@@ -41,6 +41,7 @@ interface TradingChartProps {
 }
 
 export function TradingChart({ productId }: TradingChartProps) {
+  const [isClient, setIsClient] = useState(false);
   const [period, setPeriod] = useState<Period>('1W');
   const [candles, setCandles] = useState<Candle[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -80,6 +81,10 @@ export function TradingChart({ productId }: TradingChartProps) {
   const chartHeight = height - padding.top - padding.bottom;
   const chartBaseline = padding.top + chartHeight;
   const gradientId = useId();
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
   useLayoutEffect(() => {
     const element = chartScrollRef.current;
@@ -153,11 +158,16 @@ export function TradingChart({ productId }: TradingChartProps) {
   const axisLabels = useMemo(() => {
     if (visibleData.length === 0) return [];
     const count = Math.min(5, visibleData.length);
-    if (count === 1) return [visibleData[0].t];
+    if (count === 1) {
+      return [{ label: visibleData[0].t, index: 0 }];
+    }
     const step = (visibleData.length - 1) / (count - 1);
     return Array.from({ length: count }, (_, i) => {
       const idx = Math.round(i * step);
-      return visibleData[idx]?.t ?? '';
+      return {
+        label: visibleData[idx]?.t ?? '',
+        index: idx,
+      };
     });
   }, [visibleData]);
 
@@ -402,13 +412,13 @@ export function TradingChart({ productId }: TradingChartProps) {
 
         <div
           ref={chartScrollRef}
-          className="relative -mx-4 flex-1 select-none overflow-x-auto overflow-y-hidden px-2 py-2 pb-6"
+          className="relative -mx-4 flex flex-1 select-none items-center overflow-x-auto overflow-y-hidden px-2 py-2 pb-6"
           style={scrollStyle}
         >
-          {hasData ? (
+          {isClient ? (
             <div
               ref={chartAreaRef}
-              className="relative h-full"
+              className="relative"
               style={{ height, width: baseCanvasWidth }}
               onPointerDown={handlePointerDown}
               onPointerMove={handlePointerMove}
@@ -483,11 +493,11 @@ export function TradingChart({ productId }: TradingChartProps) {
                         strokeWidth={1}
                       />
                     ))}
-                 </>
-               )}
+                  </>
+                )}
               </svg>
 
-              {hoveredPoint && (
+              {hoveredPoint && hasData && (
                 <>
                   <div
                     className="absolute"
@@ -540,24 +550,29 @@ export function TradingChart({ productId }: TradingChartProps) {
                 </>
               )}
 
-              <div
-                className="absolute bottom-[18px] left-0 right-0 flex justify-between px-8 text-[10px] text-gray-500"
-                style={{ pointerEvents: 'none' }}
-              >
-                {axisLabels.map((label, index) => (
-                  <span key={`${label}-${index}`} className="truncate">
+              <div className="pointer-events-none absolute bottom-[18px] left-0 right-0 px-8 text-[10px] text-gray-500">
+                {axisLabels.map(({ label, index }) => (
+                  <span
+                    key={`${label}-${index}`}
+                    className="absolute -translate-x-1/2 whitespace-nowrap"
+                    style={{ left: `${xScale(index)}px` }}
+                  >
                     {label}
                   </span>
                 ))}
               </div>
+
+              {!hasData && (
+                <div className="absolute inset-0 flex items-center justify-center px-4">
+                  <span className="text-xs text-slate-400">
+                    데이터가 없습니다.
+                  </span>
+                </div>
+              )}
             </div>
           ) : (
-            <div className="flex h-[320px] items-center justify-center rounded-xl border border-dashed border-slate-200 text-sm text-slate-400">
-              {errorMessage
-                ? errorMessage
-                : isLoading
-                  ? '차트 데이터를 불러오는 중...'
-                  : '차트 준비 중...'}
+            <div className="flex h-[320px] w-full items-center justify-center rounded-xl border border-dashed border-slate-200 text-sm text-slate-400">
+              차트 준비 중...
             </div>
           )}
         </div>

--- a/src/components/trade/chart/chart.tsx
+++ b/src/components/trade/chart/chart.tsx
@@ -17,6 +17,7 @@ import type { Candle } from '@/lib/mock-trading';
 import { apiFetch } from '@/lib/api-client';
 
 type Period = '1D' | '1W' | '1M';
+const PERIOD_OPTIONS: Period[] = ['1D', '1W', '1M'];
 type ChartInterval = '1d' | '1w' | '1m';
 
 type ChartApiResponse = {
@@ -383,7 +384,7 @@ export function TradingChart({ productId }: TradingChartProps) {
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold">차트</h2>
           <div className="flex gap-2">
-            {(['1D', '1W', '1M'] as Period[]).map((p) => (
+            {PERIOD_OPTIONS.map((p) => (
               <button
                 key={p}
                 onClick={() => setPeriod(p)}

--- a/src/components/trade/chart/order-form.tsx
+++ b/src/components/trade/chart/order-form.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import type { ChangeEvent } from 'react';
 
 import { Card, CardContent } from '@/components/ui/card';
 import myHomeEmptyIcon from '@/assets/images/my_home_empty_state_icon.svg';
@@ -48,19 +49,36 @@ type PendingOrder = {
 
 type PendingOrderResponse = {
   page?: number;
-  content?: Array<{
-    order_id: string;
-    side: 'buy' | 'sell';
-    order_price: number;
-    order_quantity: number;
-    created_at: string;
-  }>;
+  total?: number;
+  has_next?: boolean;
+  content?: PendingOrderPayload[];
+  orders?: PendingOrderPayload[];
+  items?: PendingOrderPayload[];
+};
+
+type PendingOrderPayload = {
+  order_id: string;
+  product_id: number;
+  product_name?: string;
+  order_type?: 'BUY' | 'SELL' | 'buy' | 'sell';
+  side?: 'buy' | 'sell';
+  price: number;
+  quantity: number;
+  filled_quantity?: number;
+  remaining_quantity?: number;
+  amount?: number;
+  order_price?: number;
+  order_quantity?: number;
+  created_at?: string;
+  placed_at?: string;
 };
 
 export function OrderForm({ currentPrice, assetSummary, productId }: OrderFormProps) {
   const [activeTab, setActiveTab] = useState<OrderTab>('buy');
   const [price, setPrice] = useState(currentPrice);
+  const [priceInput, setPriceInput] = useState(() => String(currentPrice ?? 0));
   const [quantity, setQuantity] = useState(1);
+  const [quantityInput, setQuantityInput] = useState('1');
   const [pendingOrders, setPendingOrders] = useState<PendingOrder[]>([]);
   const [hasHydrated, setHasHydrated] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -70,29 +88,66 @@ export function OrderForm({ currentPrice, assetSummary, productId }: OrderFormPr
     setHasHydrated(true);
   }, []);
 
+  const handlePriceChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (!/^\d*$/.test(value)) return;
+    setPriceInput(value);
+    setPrice(value === '' ? 0 : Number(value));
+  };
+
+  const handlePriceBlur = () => {
+    const normalized = priceInput === '' ? 0 : Number(priceInput);
+    setPrice(normalized);
+    setPriceInput(String(normalized));
+  };
+
+  const handleQuantityChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (!/^\d*$/.test(value)) return;
+    setQuantityInput(value);
+    setQuantity(value === '' ? 0 : Number(value));
+  };
+
+  const handleQuantityBlur = () => {
+    const normalized = Math.max(1, Number(quantityInput) || 1);
+    setQuantity(normalized);
+    setQuantityInput(String(normalized));
+  };
+
+  useEffect(() => {
+    setPrice(currentPrice);
+    setPriceInput(String(currentPrice ?? 0));
+  }, [currentPrice]);
+
   useEffect(() => {
     const fetchPendingOrders = async () => {
       const numericProductId = Number(productId);
       if (!Number.isFinite(numericProductId)) return;
 
       try {
-        const res = await apiFetch(`/v1/market/${numericProductId}/orderbook/status=pending`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ page: 1 }),
-        });
+        const res = await apiFetch(
+          `/v1/market/${numericProductId}/orders/pending?page=1`,
+        );
         if (!res.ok) {
           console.warn(`Failed to load pending orders: ${res.status}`);
           return;
         }
         const data = (await res.json()) as PendingOrderResponse;
-        const normalized = data.content?.map((order) => ({
-          id: order.order_id,
-          side: order.side,
-          price: order.order_price,
-          quantity: order.order_quantity,
-          createdAt: Date.parse(order.created_at) || Date.now(),
-        })) ?? [];
+        const entries = data.items ?? data.content ?? data.orders ?? [];
+        const normalized = entries.map((order) => {
+          const price = order.price ?? order.order_price ?? 0;
+          const quantity = order.quantity ?? order.order_quantity ?? 0;
+          const timestamp = order.placed_at ?? order.created_at ?? '';
+          const sideValue =
+            order.side?.toLowerCase() ?? order.order_type?.toLowerCase() ?? 'buy';
+          return {
+            id: order.order_id,
+            side: sideValue === 'sell' ? 'sell' : 'buy',
+            price,
+            quantity,
+            createdAt: timestamp ? Date.parse(timestamp) || Date.now() : Date.now(),
+          } satisfies PendingOrder;
+        });
         setPendingOrders(normalized);
       } catch (error) {
         console.error('Failed to fetch pending orders', error);
@@ -111,9 +166,16 @@ export function OrderForm({ currentPrice, assetSummary, productId }: OrderFormPr
       return;
     }
 
+    const normalizedPrice = priceInput === '' ? 0 : Number(priceInput);
+    const normalizedQuantity = Math.max(1, quantityInput === '' ? 0 : Number(quantityInput));
+    setPrice(normalizedPrice);
+    setPriceInput(String(normalizedPrice));
+    setQuantity(normalizedQuantity);
+    setQuantityInput(String(normalizedQuantity));
+
     const payload = {
-      order_price: price,
-      order_quantity: quantity,
+      order_price: normalizedPrice,
+      order_quantity: normalizedQuantity,
       client_time: new Date().toISOString(),
     };
 
@@ -155,8 +217,8 @@ export function OrderForm({ currentPrice, assetSummary, productId }: OrderFormPr
       const newOrder: PendingOrder = {
         id: data.order_id ?? `${Date.now()}`,
         side: (data.side as PendingOrder['side']) ?? activeTab,
-        price: data.order_price ?? price,
-        quantity: data.order_quantity ?? quantity,
+        price: data.order_price ?? normalizedPrice,
+        quantity: data.order_quantity ?? normalizedQuantity,
         createdAt: Number.isNaN(createdAtTs) ? Date.now() : createdAtTs,
       };
 
@@ -171,10 +233,34 @@ export function OrderForm({ currentPrice, assetSummary, productId }: OrderFormPr
     }
   };
 
-  const incrementPrice = () => setPrice((p) => p + 100);
-  const decrementPrice = () => setPrice((p) => Math.max(100, p - 100));
-  const incrementQuantity = () => setQuantity((q) => q + 1);
-  const decrementQuantity = () => setQuantity((q) => Math.max(1, q - 1));
+  const incrementPrice = () =>
+    setPrice((prev) => {
+      const current = Number.isFinite(prev) ? prev : 0;
+      const next = current + 100;
+      setPriceInput(String(next));
+      return next;
+    });
+  const decrementPrice = () =>
+    setPrice((prev) => {
+      const current = Number.isFinite(prev) ? prev : 0;
+      const next = Math.max(0, current - 100);
+      setPriceInput(String(next));
+      return next;
+    });
+  const incrementQuantity = () =>
+    setQuantity((prev) => {
+      const base = prev && prev > 0 ? prev : 0;
+      const next = base + 1;
+      setQuantityInput(String(next));
+      return next;
+    });
+  const decrementQuantity = () =>
+    setQuantity((prev) => {
+      const base = prev && prev > 0 ? prev : 1;
+      const next = Math.max(1, base - 1);
+      setQuantityInput(String(next));
+      return next;
+    });
 
   const formatCurrency = (value: number) => `${value.toLocaleString('ko-KR')}원`;
 
@@ -345,8 +431,9 @@ export function OrderForm({ currentPrice, assetSummary, productId }: OrderFormPr
                 <div className="flex items-center gap-2">
                   <input
                     type="number"
-                    value={price}
-                    onChange={(e) => setPrice(Number(e.target.value))}
+                    value={priceInput}
+                    onChange={handlePriceChange}
+                    onBlur={handlePriceBlur}
                     className="w-[132px] rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#2563EB]"
                   />
                   <span className="text-sm text-[#6B7280]">원</span>
@@ -369,16 +456,15 @@ export function OrderForm({ currentPrice, assetSummary, productId }: OrderFormPr
                 <div className="flex items-center gap-2">
                   <input
                     type="number"
-                    value={quantity}
-                    onChange={(e) =>
-                      setQuantity(Math.max(1, Number(e.target.value)))
-                    }
+                    value={quantityInput}
+                    onChange={handleQuantityChange}
+                    onBlur={handleQuantityBlur}
                     placeholder={
-                      activeTab === 'sell' ? '최대 15주 가능' : '최대 5주 가능'
+                      activeTab === 'sell' ? '최대 15토큰 가능' : '최대 5토큰 가능'
                     }
-                    className="w-[132px] rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#2563EB]"
+                    className="w-[120px] rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#2563EB]"
                   />
-                  <span className="text-sm text-[#6B7280]">주</span>
+                  <span className="text-sm text-[#6B7280] whitespace-nowrap">토큰</span>
                   <button
                     onClick={decrementQuantity}
                     className="flex h-9 w-9 items-center justify-center rounded-lg border bg-white text-lg text-[#6B7280] hover:bg-gray-50"
@@ -462,7 +548,7 @@ export function OrderForm({ currentPrice, assetSummary, productId }: OrderFormPr
                         <div className="flex justify-between">
                           <span>수량</span>
                           <span className="text-sm font-medium text-[#111827]">
-                            {order.quantity.toLocaleString('ko-KR')}주
+                            {order.quantity.toLocaleString('ko-KR')}토큰
                           </span>
                         </div>
                         <div className="flex justify-between">
@@ -553,11 +639,11 @@ export function OrderForm({ currentPrice, assetSummary, productId }: OrderFormPr
                 <div className="grid grid-cols-[auto_auto] items-baseline gap-x-6">
                   <dt className="text-xs text-[#6B7280]">수량</dt>
                   <dd className="text-right text-sm font-medium text-[#6B7280]">
-                    {assetSummary.quantity.toLocaleString('ko-KR')}주
+                    {assetSummary.quantity.toLocaleString('ko-KR')}토큰
                   </dd>
                 </div>
                 <div className="grid grid-cols-[auto_auto] items-baseline gap-x-6">
-                  <dt className="text-xs text-[#6B7280]">1주 평균 금액</dt>
+                  <dt className="text-xs text-[#6B7280]">1토큰 평균 금액</dt>
                   <dd className="text-right text-sm font-medium text-[#6B7280]">
                     {formatCurrency(assetSummary.avgBuyPrice)}
                   </dd>

--- a/src/components/trade/chart/orderbook.tsx
+++ b/src/components/trade/chart/orderbook.tsx
@@ -26,8 +26,10 @@ export interface OrderBookProps {
 }
 
 export function OrderBook({ summary, ordersSell = [], ordersBuy = [] }: OrderBookProps) {
-  const totalSell = ordersSell.reduce((acc, row) => acc + row.quantity, 0);
-  const totalBuy = ordersBuy.reduce((acc, row) => acc + row.quantity, 0);
+  const sortedSells = [...ordersSell].sort((a, b) => b.price - a.price);
+  const sortedBuys = [...ordersBuy].sort((a, b) => a.price - b.price);
+  const totalSell = sortedSells.reduce((acc, row) => acc + row.quantity, 0);
+  const totalBuy = sortedBuys.reduce((acc, row) => acc + row.quantity, 0);
   const formatNumber = (value: number) => value.toLocaleString('ko-KR');
   const formatChange = (value: number) => `${value >= 0 ? '+' : ''}${value.toFixed(1)}%`;
   const hasData = ordersSell.length > 0 || ordersBuy.length > 0;
@@ -63,7 +65,7 @@ export function OrderBook({ summary, ordersSell = [], ordersBuy = [] }: OrderBoo
                 호가 데이터를 불러오는 중...
               </div>
             )}
-            {ordersSell.map((row) => (
+            {sortedSells.map((row) => (
               <div
                 key={`ask-${row.price}`}
                 className="grid grid-cols-3 items-center rounded-lg px-3 py-4 text-sm transition-colors hover:bg-[#F2F4F7] text-center"
@@ -87,7 +89,7 @@ export function OrderBook({ summary, ordersSell = [], ordersBuy = [] }: OrderBoo
 
             <div className="my-1 h-px rounded-full bg-slate-200" />
 
-            {ordersBuy.map((row) => (
+            {sortedBuys.map((row) => (
               <div
                 key={`bid-${row.price}`}
                 className="grid grid-cols-3 items-center rounded-lg px-3 py-4 text-sm transition-colors hover:bg-[#F2F4F7] text-center"

--- a/src/components/trade/chart/orderbook.tsx
+++ b/src/components/trade/chart/orderbook.tsx
@@ -62,7 +62,7 @@ export function OrderBook({ summary, ordersSell = [], ordersBuy = [] }: OrderBoo
           <div className="flex-1 space-y-2 overflow-y-auto px-4 py-2">
             {!hasData && (
               <div className="flex h-full items-center justify-center text-xs text-slate-400">
-                호가 데이터를 불러오는 중...
+                데이터가 없습니다.
               </div>
             )}
             {sortedSells.map((row) => (

--- a/src/components/trade/info/info-panel.tsx
+++ b/src/components/trade/info/info-panel.tsx
@@ -28,15 +28,22 @@ export function RevenueInfoCard({ info }: InfoCardProps) {
 }
 
 export function IpIntroCard({ info }: InfoCardProps) {
+  const hasSummary = Boolean(info.summary && info.summary.trim().length > 0);
   return (
     <Card className="flex h-[360px] flex-col rounded-2xl border shadow-sm overflow-hidden">
       <CardContent className="flex flex-1 flex-col p-6 pb-4 overflow-hidden">
         <h3 className="text-[15px] font-semibold text-[#111827] mb-4">
           IP 소개
         </h3>
-        <p className="flex-1 text-sm text-gray-700 leading-relaxed mb-2 overflow-y-auto pr-1">
-          {info.summary}
-        </p>
+        {hasSummary ? (
+          <p className="flex-1 text-sm text-gray-700 leading-relaxed mb-2 overflow-y-auto pr-1">
+            {info.summary}
+          </p>
+        ) : (
+          <div className="flex flex-1 items-center justify-center rounded-lg border border-dashed border-gray-200 bg-gray-50/50 text-sm text-gray-500 mb-2">
+            데이터가 없습니다.
+          </div>
+        )}
         <div className="space-y-0 border rounded-lg overflow-hidden">
           <div className="grid grid-cols-[140px_1fr] text-sm border-b last:border-b-0">
             <div className="bg-gray-50/40 p-3 text-gray-600 font-medium">

--- a/src/components/trade/info/notice-panel.tsx
+++ b/src/components/trade/info/notice-panel.tsx
@@ -76,57 +76,65 @@ export function NoticePanel({ notices }: NoticePanelProps = {}) {
           ref={containerRef}
           className="notice-scroll flex-1 min-h-0 overflow-y-auto pr-2 space-y-4"
         >
-          {groupedEntries.map(([year, notices]) => {
-            const items = notices.slice(
-              0,
-              Math.max(0, visibleCount - rendered),
-            );
-            rendered += items.length;
-            if (items.length === 0) return null;
+          {sourceNotices.length === 0 ? (
+            <div className="flex h-full items-center justify-center rounded-lg border border-dashed border-gray-200 bg-gray-50/50 text-sm text-gray-500">
+              데이터가 없습니다.
+            </div>
+          ) : (
+            <>
+              {groupedEntries.map(([year, notices]) => {
+                const items = notices.slice(
+                  0,
+                  Math.max(0, visibleCount - rendered),
+                );
+                rendered += items.length;
+                if (items.length === 0) return null;
 
-            return (
-              <div key={year}>
-                <h4 className="text-sm font-bold text-gray-900 mb-2">
-                  {year}년
-                </h4>
-                <div className="space-y-2">
-                  {items.map((notice) => (
-                    <Link
-                      key={notice.id}
-                      href={notice.url ?? '#'}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex w-full items-start justify-between gap-4 rounded-lg p-3 text-left transition-colors hover:bg-gray-50 group"
-                      onClick={() => handleNoticeClick(notice.id)}
-                    >
-                      <div className="flex items-start gap-3">
-                        <div className="text-xs text-gray-500 whitespace-nowrap pt-0.5 min-w-[60px]">
-                          {formatDate(notice.date)}
-                        </div>
-                        <div className="flex-1 min-w-0">
-                          <div className="font-semibold text-sm text-gray-900 mb-0.5 line-clamp-2">
-                            {notice.title}
-                          </div>
-                          {notice.subtitle && (
-                            <div className="text-xs text-gray-500">
-                              {notice.subtitle}
+                return (
+                  <div key={year}>
+                    <h4 className="text-sm font-bold text-gray-900 mb-2">
+                      {year}년
+                    </h4>
+                    <div className="space-y-2">
+                      {items.map((notice) => (
+                        <Link
+                          key={notice.id}
+                          href={notice.url ?? '#'}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex w-full items-start justify-between gap-4 rounded-lg p-3 text-left transition-colors hover:bg-gray-50 group"
+                          onClick={() => handleNoticeClick(notice.id)}
+                        >
+                          <div className="flex items-start gap-3">
+                            <div className="text-xs text-gray-500 whitespace-nowrap pt-0.5 min-w-[60px]">
+                              {formatDate(notice.date)}
                             </div>
-                          )}
-                        </div>
-                        <ChevronRight className="w-4 h-4 text-gray-400 flex-shrink-0 mt-0.5 group-hover:text-gray-600 transition-colors" />
-                      </div>
-                    </Link>
-                  ))}
-                </div>
+                            <div className="flex-1 min-w-0">
+                              <div className="font-semibold text-sm text-gray-900 mb-0.5 line-clamp-2">
+                                {notice.title}
+                              </div>
+                              {notice.subtitle && (
+                                <div className="text-xs text-gray-500">
+                                  {notice.subtitle}
+                                </div>
+                              )}
+                            </div>
+                            <ChevronRight className="w-4 h-4 text-gray-400 flex-shrink-0 mt-0.5 group-hover:text-gray-600 transition-colors" />
+                          </div>
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+              <div
+                ref={loadingRef}
+                className="py-4 text-center text-xs text-gray-400"
+              >
+                {visibleCount >= sourceNotices.length ? '' : '불러오는 중...'}
               </div>
-            );
-          })}
-          <div
-            ref={loadingRef}
-            className="py-4 text-center text-xs text-gray-400"
-          >
-            {visibleCount >= sourceNotices.length ? '' : '불러오는 중...'}
-          </div>
+            </>
+          )}
         </div>
       </CardContent>
       <style jsx>{`

--- a/src/components/trade/trade-card.tsx
+++ b/src/components/trade/trade-card.tsx
@@ -52,7 +52,7 @@ export function TradeCard({ item, onLikeToggle }: TradeCardProps) {
 
   return (
     <Card
-      className="group relative overflow-hidden rounded-2xl border border-gray-200 bg-white transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#1A4DE5]"
+      className="group relative overflow-hidden rounded-xl border border-gray-200 bg-white transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#1A4DE5]"
       onClick={handleCardNavigation}
       role="button"
       tabIndex={0}
@@ -87,7 +87,7 @@ export function TradeCard({ item, onLikeToggle }: TradeCardProps) {
           </button>
         </div>
 
-        <div className="p-4">
+        <div className="p-3">
           <div className="flex items-start justify-between mb-2">
             <div className="flex-1 min-w-0">
               <h3 className="text-sm font-semibold mb-0.5 truncate">


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 2차거래 시세 차트 조회 API 연결
- 구매, 판매, 대기 API 테스트
- UI 수정
  - header, footer 각 페이지마다 좌우 여백 다르게
  - header 고정 아니고 전체 스크롤 되게
  - 2차거래 리스트 카드 크기 변경
  - 차트 vertical, horizon 기준으로 center 정렬


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- close: #25 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
| 제목 | 화면 캡처 |
| ---- | -------- |
| 전체 header/footer 반영 |  ![fo](https://github.com/user-attachments/assets/fa0118df-67bb-44c3-814d-0c57ffd6fb0a) |
| 거래 상세 페이지 동작 확인 | ![bo](https://github.com/user-attachments/assets/010c29f7-508a-467a-8113-659d3d989f4e)|