### PR TITLE
[#90] chore: Frontend PROD CI/CD Slack 알림 및 README 빌드 제외

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -17,6 +17,8 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.export-image-tag.outputs.value }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -137,29 +139,45 @@ jobs:
             git push origin develop
           fi
 
+      - name: Export image tag for downstream jobs
+        id: export-image-tag
+        run: echo "value=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+
   notify:
     name: Notify CI/CD result to Slack (Frontend)
     runs-on: ubuntu-latest
-    needs: build-and-push
-    # ✅ 빌드 성공/실패/취소 모두 알림 보내기
+    needs:
+      - build-and-push
+    # 🔔 성공/실패/취소 모두 알림
     if: ${{ always() }}
     steps:
       - name: Send Slack notification
         env:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          JOB_STATUS: ${{ needs.build-and-push.result }}
+          BUILD_STATUS: ${{ needs.build-and-push.result }}
+          IMAGE_TAG: ${{ needs.build-and-push.outputs.image-tag }}
         run: |
-          if [ "$JOB_STATUS" = "success" ]; then
+          echo "Build Job: $BUILD_STATUS"
+
+          # 전체 파이프라인 상태 계산 (프론트는 단일 job 기준)
+          if [ "$BUILD_STATUS" = "success" ]; then
+            PIPELINE_STATUS="success"
             COLOR="good"
-          elif [ "$JOB_STATUS" = "cancelled" ]; then
+          elif [ "$BUILD_STATUS" = "cancelled" ]; then
+            PIPELINE_STATUS="cancelled"
             COLOR="#AAAAAA"
           else
+            PIPELINE_STATUS="failure"
             COLOR="danger"
+          fi
+
+          if [ -z "$IMAGE_TAG" ]; then
+            IMAGE_TAG="(build failed or skipped)"
           fi
 
           PAYLOAD=$(cat <<EOF
           {
-            "text": "[FRONTEND] IPiece PROD CI/CD 결과: *$JOB_STATUS*",
+            "text": "[FRONTEND] IPiece PROD CI/CD 결과: *$PIPELINE_STATUS*",
             "attachments": [
               {
                 "color": "$COLOR",
@@ -175,9 +193,14 @@ jobs:
                     "short": true
                   },
                   {
-                    "title": "커밋",
-                    "value": "${{ github.sha }}",
-                    "short": false
+                    "title": "이미지 태그",
+                    "value": "$IMAGE_TAG",
+                    "short": true
+                  },
+                  {
+                    "title": "Build / Deploy",
+                    "value": "$BUILD_STATUS",
+                    "short": true
                   },
                   {
                     "title": "실행자",


### PR DESCRIPTION
## 📌 Summary
Frontend PROD CI/CD 파이프라인에 Slack 알림을 연동하고, README 등 문서만 변경된 경우 빌드가 돌지 않도록 트리거를 조정했습니다.

## ✍️ Description
- close: #90

- `deploy-prod.yml`에 Slack Incoming Webhook 기반 알림 job(`notify`) 추가  
  - 레포지토리 Secret `SLACK_WEBHOOK_URL`을 사용해 파이프라인 결과를 지정된 Slack 채널로 전송
  - 메시지에 레포지토리, 브랜치, 이미지 태그, Build/Deploy 상태, 실행자, GitHub Actions 실행 링크 포함
- `build-and-push` job에서 `IMAGE_TAG`를 `outputs.image-tag`로 export 하여 `notify` job에서 재사용
- README(.md) 파일만 변경된 커밋은 CI/CD가 실행되지 않도록 `paths-ignore: '**/*.md'` 설정 추가
- 백엔드 PROD CI/CD Slack 알림 포맷과 최대한 동일하게 맞춰, 운영자가 Front/Back 결과를 한눈에 비교하기 쉽게 구성

## 💡 PR Point
- Slack Webhook URL이 레포지토리 Secrets(`SLACK_WEBHOOK_URL`)에 미리 설정되어 있어야 알림이 정상 전송됩니다.
- 현재 파이프라인 상태 계산은 단일 job(`build-and-push`)의 `result` 기준으로 이루어집니다.
- 추후 job을 분리(lint / build / test 등)할 경우, `needs`와 상태 계산 로직만 보강하면 동일한 메시지 포맷으로 확장 가능합니다.

## 📚 Reference 
- #90 IPiece Frontend PROD CI/CD Slack 알림 연동 이슈

## 🔥 Test
- [ ] `develop` 브랜치에 일반 코드 변경 푸시 후 GitHub Actions 실행 및 Slack 알림 내용 확인
- [ ] README.md만 수정한 커밋 푸시 시 워크플로우 미실행 여부 확인
